### PR TITLE
[9.102.x-prod] update artifacts cache to a valid md5sum for OSL images

### DIFF
--- a/packages/osl-data-index-ephemeral-image/generated/modules/osl-data-index-ephemeral/module.yaml
+++ b/packages/osl-data-index-ephemeral-image/generated/modules/osl-data-index-ephemeral/module.yaml
@@ -22,8 +22,8 @@ version: "1.35.0"
 
 artifacts:
   - name: data-index-service-inmemory
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "data-index-service-inmemory-9.102.0.redhat-00004-image-build.zip"
+    md5: "8cf4a238679da32f22d68d75aecc6054"
     target: data-index-service-inmemory-image-build.zip
 
 execute:

--- a/packages/osl-data-index-ephemeral-image/resources/modules/osl-data-index-ephemeral/module.yaml
+++ b/packages/osl-data-index-ephemeral-image/resources/modules/osl-data-index-ephemeral/module.yaml
@@ -22,8 +22,8 @@ version: "main"
 
 artifacts:
   - name: data-index-service-inmemory
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "data-index-service-inmemory-9.102.0.redhat-00004-image-build.zip"
+    md5: "8cf4a238679da32f22d68d75aecc6054"
     target: data-index-service-inmemory-image-build.zip
 
 execute:

--- a/packages/osl-data-index-postgresql-image/generated/modules/osl-data-index-postgresql/module.yaml
+++ b/packages/osl-data-index-postgresql-image/generated/modules/osl-data-index-postgresql/module.yaml
@@ -22,8 +22,8 @@ version: "1.35.0"
 
 artifacts:
   - name: data-index-service-postgresql
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "data-index-service-postgresql-9.102.0.redhat-00004-image-build.zip"
+    md5: "9fdcabfae89321d4ebdf4fc34e50061b"
     target: data-index-service-postgresql-image-build.zip
 
 execute:

--- a/packages/osl-data-index-postgresql-image/resources/modules/osl-data-index-postgresql/module.yaml
+++ b/packages/osl-data-index-postgresql-image/resources/modules/osl-data-index-postgresql/module.yaml
@@ -22,8 +22,8 @@ version: "main"
 
 artifacts:
   - name: data-index-service-postgresql
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "data-index-service-postgresql-9.102.0.redhat-00004-image-build.zip"
+    md5: "9fdcabfae89321d4ebdf4fc34e50061b"
     target: data-index-service-postgresql-image-build.zip
 
 execute:

--- a/packages/osl-jobs-service-ephemeral-image/generated/modules/osl-jobs-service-ephemeral/module.yaml
+++ b/packages/osl-jobs-service-ephemeral-image/generated/modules/osl-jobs-service-ephemeral/module.yaml
@@ -22,8 +22,8 @@ version: "1.35.0"
 
 artifacts:
   - name: jobs-service-inmemory
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "jobs-service-inmemory-9.102.0.redhat-00004-image-build.zip"
+    md5: "ad090d1f9f12dde67f8022aaeb68d745"
     target: jobs-service-inmemory-image-build.zip
 
 packages:

--- a/packages/osl-jobs-service-ephemeral-image/resources/modules/osl-jobs-service-ephemeral/module.yaml
+++ b/packages/osl-jobs-service-ephemeral-image/resources/modules/osl-jobs-service-ephemeral/module.yaml
@@ -22,8 +22,8 @@ version: "main"
 
 artifacts:
   - name: jobs-service-inmemory
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "jobs-service-inmemory-9.102.0.redhat-00004-image-build.zip"
+    md5: "ad090d1f9f12dde67f8022aaeb68d745"
     target: jobs-service-inmemory-image-build.zip
 
 packages:

--- a/packages/osl-jobs-service-postgresql-image/generated/modules/osl-jobs-service-postgresql/module.yaml
+++ b/packages/osl-jobs-service-postgresql-image/generated/modules/osl-jobs-service-postgresql/module.yaml
@@ -22,8 +22,8 @@ version: "1.35.0"
 
 artifacts:
   - name: jobs-service-postgresql
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "jobs-service-postgresql-9.102.0.redhat-00004-image-build.zip"
+    md5: "87ca8142a52adc4e9f4fa20c821e2c74"
     target: jobs-service-postgresql-image-build.zip
 
 packages:

--- a/packages/osl-jobs-service-postgresql-image/resources/modules/osl-jobs-service-postgresql/module.yaml
+++ b/packages/osl-jobs-service-postgresql-image/resources/modules/osl-jobs-service-postgresql/module.yaml
@@ -22,8 +22,8 @@ version: "main"
 
 artifacts:
   - name: jobs-service-postgresql
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "jobs-service-postgresql-9.102.0.redhat-00004-image-build.zip"
+    md5: "87ca8142a52adc4e9f4fa20c821e2c74"
     target: jobs-service-postgresql-image-build.zip
 
 packages:

--- a/packages/osl-management-console-image/generated/modules/osl-management-console/module.yaml
+++ b/packages/osl-management-console-image/generated/modules/osl-management-console/module.yaml
@@ -31,7 +31,7 @@ envs:
 
 artifacts:
   - name: sonataflow-management-console-webapp
-    description: "## UPDATED DURING BUILD ##"
+    description: "sonataflow-management-console-webapp-9.102.0.redhat-00004-image-build"
     dest: /home/kogito/management-console/app
     target: sonataflow-management-console-webapp-image-build.zip
-    md5: "## UPDATED DURING BUILD ##"
+    md5: "e1dd25a794ed2bf92f010437dc65eed6"

--- a/packages/osl-management-console-image/resources/modules/osl-management-console/module.yaml
+++ b/packages/osl-management-console-image/resources/modules/osl-management-console/module.yaml
@@ -31,7 +31,7 @@ envs:
 
 artifacts:
   - name: sonataflow-management-console-webapp
-    description: "## UPDATED DURING BUILD ##"
+    description: "sonataflow-management-console-webapp-9.102.0.redhat-00004-image-build"
     dest: /home/kogito/management-console/app
     target: sonataflow-management-console-webapp-image-build.zip
-    md5: "## UPDATED DURING BUILD ##"
+    md5: "e1dd25a794ed2bf92f010437dc65eed6"

--- a/packages/osl-swf-builder-image/generated/modules/osl-swf-builder-runtime/module.yaml
+++ b/packages/osl-swf-builder-image/generated/modules/osl-swf-builder-runtime/module.yaml
@@ -23,12 +23,12 @@ description: "OpenShift Serverless Logic builder module with required extensions
 
 artifacts:
   - name: kogito-builder-quarkus-app
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "kogito-builder-quarkus-app-9.102.0.redhat-00004-image-build.zip"
+    md5: "56446e0ecf816ebf1ecc0b03c00fe5a9"
     target: kogito-builder-quarkus-app-image-build.zip
   - name: kogito-builder-maven-repository
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "kogito-builder-maven-repository-9.102.0.redhat-00004-image-build.zip"
+    md5: "75953ad4e284b83302a8f7347cedd3a7"
     target: kogito-builder-maven-repository-image-build.zip
 
 execute:

--- a/packages/osl-swf-builder-image/resources/modules/osl-swf-builder-runtime/module.yaml
+++ b/packages/osl-swf-builder-image/resources/modules/osl-swf-builder-runtime/module.yaml
@@ -23,12 +23,12 @@ description: "OpenShift Serverless Logic builder module with required extensions
 
 artifacts:
   - name: kogito-builder-quarkus-app
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "kogito-builder-quarkus-app-9.102.0.redhat-00004-image-build.zip"
+    md5: "56446e0ecf816ebf1ecc0b03c00fe5a9"
     target: kogito-builder-quarkus-app-image-build.zip
   - name: kogito-builder-maven-repository
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "kogito-builder-maven-repository-9.102.0.redhat-00004-image-build.zip"
+    md5: "75953ad4e284b83302a8f7347cedd3a7"
     target: kogito-builder-maven-repository-image-build.zip
 
 execute:

--- a/packages/osl-swf-devmode-image/generated/modules/osl-swf-devmode-runtime/module.yaml
+++ b/packages/osl-swf-devmode-image/generated/modules/osl-swf-devmode-runtime/module.yaml
@@ -43,12 +43,12 @@ envs:
 
 artifacts:
   - name: kogito-devmode-quarkus-app
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "kogito-devmode-quarkus-app-9.102.0.redhat-00004-image-build.zip"
+    md5: "3826066b2967135dbd7bea0f50bb2105"
     target: kogito-devmode-quarkus-app-image-build.zip
   - name: kogito-devmode-maven-repository
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "kogito-devmode-maven-repository-9.102.0.redhat-00004-image-build.zip"
+    md5: "750c96be4767210eb85823e43706f3b5"
     target: kogito-devmode-maven-repository-image-build.zip
 
 execute:

--- a/packages/osl-swf-devmode-image/resources/modules/osl-swf-devmode-runtime/module.yaml
+++ b/packages/osl-swf-devmode-image/resources/modules/osl-swf-devmode-runtime/module.yaml
@@ -43,12 +43,12 @@ envs:
 
 artifacts:
   - name: kogito-devmode-quarkus-app
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "kogito-devmode-quarkus-app-9.102.0.redhat-00004-image-build.zip"
+    md5: "3826066b2967135dbd7bea0f50bb2105"
     target: kogito-devmode-quarkus-app-image-build.zip
   - name: kogito-devmode-maven-repository
-    description: "## UPDATED DURING BUILD ##"
-    md5: "## UPDATED DURING BUILD ##"
+    description: "kogito-devmode-maven-repository-9.102.0.redhat-00004-image-build.zip"
+    md5: "750c96be4767210eb85823e43706f3b5"
     target: kogito-devmode-maven-repository-image-build.zip
 
 execute:


### PR DESCRIPTION
cherry-pick of https://github.com/kubesmarts/kie-tools/pull/24