### PR TITLE
NO-ISSUE: fix sync main capture uncommitted changes step

### DIFF
--- a/.github/supporting-files/ci/templates/osl_sync_pr_template.md
+++ b/.github/supporting-files/ci/templates/osl_sync_pr_template.md
@@ -7,5 +7,5 @@ This pull request has been created by a GitHub workflow to synchronize the main 
 
 <details>
 <summary>Resolved conflicts:</summary>
-$SYNC_CHANGES
+$TRUNCATED_SYNC_CHANGES
 </details>

--- a/.github/workflows/osl_sync_main.yml
+++ b/.github/workflows/osl_sync_main.yml
@@ -68,22 +68,22 @@ jobs:
           git checkout upstream/main -- pnpm-lock.yaml repo/graph.*
           pnpm bootstrap --no-frozen-lockfile
 
-      - name: Run Bootstrap (No Conflicts)
-        if: env.MERGE_RESULT == 'SUCCESS'
-        run: |
-          pnpm bootstrap --no-frozen-lockfile
-
-      - name: "Run Build"
-        shell: bash
-        env:
-          KIE_TOOLS_BUILD__runTests: "false"
-          KIE_TOOLS_BUILD__runEndToEndTests: "false"
-          KIE_TOOLS_BUILD__buildContainerImages: "true"
-          KIE_TOOLS_BUILD__ignoreTestFailures: "true"
-          KIE_TOOLS_BUILD__ignoreEndToEndTestFailures: "true"
-          NODE_OPTIONS: "--max_old_space_size=4096"
-        run: >-
-          eval "pnpm ${{ env.PNPM_FILTER }} --workspace-concurrency=1 build:prod"
+      # - name: Run Bootstrap (No Conflicts)
+      #   if: env.MERGE_RESULT == 'SUCCESS'
+      #   run: |
+      #     pnpm bootstrap --no-frozen-lockfile
+      #
+      # - name: "Run Build"
+      #   shell: bash
+      #   env:
+      #     KIE_TOOLS_BUILD__runTests: "false"
+      #     KIE_TOOLS_BUILD__runEndToEndTests: "false"
+      #     KIE_TOOLS_BUILD__buildContainerImages: "true"
+      #     KIE_TOOLS_BUILD__ignoreTestFailures: "true"
+      #     KIE_TOOLS_BUILD__ignoreEndToEndTestFailures: "true"
+      #     NODE_OPTIONS: "--max_old_space_size=4096"
+      #   run: >-
+      #     eval "pnpm ${{ env.PNPM_FILTER }} --workspace-concurrency=1 build:prod"
 
       - name: Capture Uncommitted Changes
         id: capture_changes

--- a/.github/workflows/osl_sync_main.yml
+++ b/.github/workflows/osl_sync_main.yml
@@ -89,8 +89,7 @@ jobs:
         id: capture_changes
         run: |
           SYNC_CHANGES=$(git status --porcelain)
-          echo "$SYNC_CHANGES" > /tmp/sync_changes.txt
-          if [ -s /tmp/sync_changes.txt ]; then
+          if [ -n "$SYNC_CHANGES" ]; then
             echo "HAS_CHANGES=true" >> $GITHUB_ENV
           else
             echo "HAS_CHANGES=false" >> $GITHUB_ENV
@@ -129,5 +128,5 @@ jobs:
           fi
           gh pr create --title "${prTitle}" \
                        --body-file temp.md \
-                       --repo kubesmarts/kie-tools \
+                       --repo fantonangeli/kie-tools \
                        --base main $reviewersOption

--- a/.github/workflows/osl_sync_main.yml
+++ b/.github/workflows/osl_sync_main.yml
@@ -68,22 +68,22 @@ jobs:
           git checkout upstream/main -- pnpm-lock.yaml repo/graph.*
           pnpm bootstrap --no-frozen-lockfile
 
-      # - name: Run Bootstrap (No Conflicts)
-      #   if: env.MERGE_RESULT == 'SUCCESS'
-      #   run: |
-      #     pnpm bootstrap --no-frozen-lockfile
-      #
-      # - name: "Run Build"
-      #   shell: bash
-      #   env:
-      #     KIE_TOOLS_BUILD__runTests: "false"
-      #     KIE_TOOLS_BUILD__runEndToEndTests: "false"
-      #     KIE_TOOLS_BUILD__buildContainerImages: "true"
-      #     KIE_TOOLS_BUILD__ignoreTestFailures: "true"
-      #     KIE_TOOLS_BUILD__ignoreEndToEndTestFailures: "true"
-      #     NODE_OPTIONS: "--max_old_space_size=4096"
-      #   run: >-
-      #     eval "pnpm ${{ env.PNPM_FILTER }} --workspace-concurrency=1 build:prod"
+      - name: Run Bootstrap (No Conflicts)
+        if: env.MERGE_RESULT == 'SUCCESS'
+        run: |
+          pnpm bootstrap --no-frozen-lockfile
+
+      - name: "Run Build"
+        shell: bash
+        env:
+          KIE_TOOLS_BUILD__runTests: "false"
+          KIE_TOOLS_BUILD__runEndToEndTests: "false"
+          KIE_TOOLS_BUILD__buildContainerImages: "true"
+          KIE_TOOLS_BUILD__ignoreTestFailures: "true"
+          KIE_TOOLS_BUILD__ignoreEndToEndTestFailures: "true"
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        run: >-
+          eval "pnpm ${{ env.PNPM_FILTER }} --workspace-concurrency=1 build:prod"
 
       - name: Capture Uncommitted Changes
         id: capture_changes
@@ -138,5 +138,5 @@ jobs:
           fi
           gh pr create --title "${prTitle}" \
                        --body-file temp.md \
-                       --repo fantonangeli/kie-tools \
+                       --repo kubesmarts/kie-tools \
                        --base main $reviewersOption

--- a/.github/workflows/osl_sync_main.yml
+++ b/.github/workflows/osl_sync_main.yml
@@ -117,10 +117,19 @@ jobs:
         run: |
           set -x
           SYNC_CHANGES=$(cat /tmp/sync_changes.txt)
-          ESCAPED_CHANGES=$(echo "$SYNC_CHANGES" | sed -e ':a' -e 'N' -e '$!ba' -e 's|\n|\\n|g' -e 's|/|\\/|g')
+
+          # Truncate SYNC_CHANGES to 5000 
+          MAX_CHARS=5000
+          if [ ${#SYNC_CHANGES} -gt $MAX_CHARS ]; then
+            TRUNCATED_SYNC_CHANGES="${SYNC_CHANGES:0:$MAX_CHARS}..."
+          else
+            TRUNCATED_SYNC_CHANGES="$SYNC_CHANGES"
+          fi
+
+          ESCAPED_CHANGES=$(echo "$TRUNCATED_SYNC_CHANGES" | sed -e ':a' -e 'N' -e '$!ba' -e 's|\n|\\n|g' -e 's|/|\\/|g')
 
           # Use double quotes for variable substitution in sed
-          sed -e "s|\\\$RUN_URL|${RUN_URL}|g" -e "s|\\\$SYNC_CHANGES|${ESCAPED_CHANGES}|g" .github/supporting-files/ci/templates/osl_sync_pr_template.md > temp.md
+          sed -e "s|\\\$RUN_URL|${RUN_URL}|g" -e "s|\\\$TRUNCATED_SYNC_CHANGES|${ESCAPED_CHANGES}|g" .github/supporting-files/ci/templates/osl_sync_pr_template.md > temp.md
 
           prTitle="[$(date +'%Y-%m-%d:%H%M%S')] - :robot: Automated PR: Sync main with upstream"
           reviewersOption=""

--- a/.github/workflows/osl_sync_main.yml
+++ b/.github/workflows/osl_sync_main.yml
@@ -89,6 +89,7 @@ jobs:
         id: capture_changes
         run: |
           SYNC_CHANGES=$(git status --porcelain)
+          echo "$SYNC_CHANGES" > /tmp/sync_changes.txt
           if [ -n "$SYNC_CHANGES" ]; then
             echo "HAS_CHANGES=true" >> $GITHUB_ENV
           else


### PR DESCRIPTION
This PR fixes a check related to the `git status --porcelain` output.

This fixes also an error: 
`pull request create failed: GraphQL: Body is too long (maximum is 65536 characters)`
which happens when `SYNC_CHANGES` is too big and truncate it with `...`

I tested the CI running on my for with:
- an old `kubesmarts/kie-tools:main` branch with last commit on 11-12-2024:
https://github.com/fantonangeli/kie-tools/pull/35
- an updated `kubesmarts/kie-tools:main` branch
https://github.com/fantonangeli/kie-tools/pull/36