### PR TITLE
SRVLOGIC-511: Move daily_dev_publish GH Workflow

### DIFF
--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -110,7 +110,7 @@ jobs:
       - name: "Checkout serverless-logic-sandbox-deployment"
         uses: actions/checkout@v3
         with:
-          token: ${{ github.event_name != 'pull_request' && secrets.KIE_GROUP_TOOLS_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ github.event_name != 'pull_request' && secrets.KIE1_TOKEN || secrets.GITHUB_TOKEN }}
           path: serverless-logic-sandbox-deployment
           repository: ${{ env.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
           ref: gh-pages

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -80,42 +80,35 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven
-      #
-      # - name: "Setup environment"
-      #   uses: ./kie-tools/.github/actions/setup-env
-      #   with:
-      #     working_dir: kie-tools
-      #
-      # - name: "Bootstrap"
-      #   id: bootstrap
-      #   uses: ./kie-tools/.github/actions/bootstrap
-      #   with:
-      #     working_dir: kie-tools
-      #
-      # - name: "Parse `commit_sha`"
-      #   id: commit_sha
-      #   shell: bash
-      #   run: |
-      #     cd kie-tools
-      #     echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      #
-      # - name: "Build serverless-logic-web-tools"
-      #   run: |
-      #     if [ "${{ inputs.environment }}" = "dev" ]; then
-      #       export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ steps.version.outputs.version }} (daily-dev) @ ${{ steps.commit_sha.outputs.commit_sha }}"
-      #     elif [ "${{ inputs.environment }}" = "staging" ]; then
-      #       export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ inputs.tag }} (staging) @ ${{ steps.commit_sha.outputs.commit_sha }}"
-      #     fi
-      #     echo "SERVERLESS_LOGIC_WEB_TOOLS__buildInfo=$SERVERLESS_LOGIC_WEB_TOOLS__buildInfo"
-      #     cd kie-tools
-      #     pnpm -F @kie-tools/serverless-logic-web-tools... build:prod
 
-      - name: "Write testfile.txt"
+      - name: "Setup environment"
+        uses: ./kie-tools/.github/actions/setup-env
+        with:
+          working_dir: kie-tools
+
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          working_dir: kie-tools
+
+      - name: "Parse `commit_sha`"
         id: commit_sha
         shell: bash
         run: |
-          mkdir -p kie-tools/packages/serverless-logic-web-tools/dist/
-          echo "ok" > kie-tools/packages/serverless-logic-web-tools/dist/testfile.txt
+          cd kie-tools
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: "Build serverless-logic-web-tools"
+        run: |
+          if [ "${{ inputs.environment }}" = "dev" ]; then
+            export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ steps.version.outputs.version }} (daily-dev) @ ${{ steps.commit_sha.outputs.commit_sha }}"
+          elif [ "${{ inputs.environment }}" = "staging" ]; then
+            export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ inputs.tag }} (staging) @ ${{ steps.commit_sha.outputs.commit_sha }}"
+          fi
+          echo "SERVERLESS_LOGIC_WEB_TOOLS__buildInfo=$SERVERLESS_LOGIC_WEB_TOOLS__buildInfo"
+          cd kie-tools
+          pnpm -F @kie-tools/serverless-logic-web-tools... build:prod
 
       - name: "Checkout serverless-logic-sandbox-deployment"
         uses: actions/checkout@v3

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -25,6 +25,7 @@ env:
   DASHBUILDER__viewerImageAccount: "kubesmarts"
   DASHBUILDER__viewerImageName: "incubator-kie-dashbuilder-viewer"
   DASHBUILDER__viewerImageRegistry: "quay.io"
+  GITHUB_TOKEN: ${{ secrets.KIE1_TOKEN }}
   KIE_TOOLS_BUILD__buildContainerImages: "false"
   KIE_TOOLS_BUILD__runEndToEndTests: "false"
   KIE_TOOLS_BUILD__runLinters: "false"
@@ -56,6 +57,11 @@ jobs:
     if: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO != '' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Git Environment
+        run: |
+          git config --global user.name "${{ secrets.KIE1_USER_NAME }}"
+          git config --global user.email "${{ secrets.KIE1_EMAIL }}"
+
       - name: "Clone kie-tools"
         uses: actions/checkout@v3
         with:
@@ -142,8 +148,6 @@ jobs:
             mkdir -p $DEPLOYMENT_DIR
           fi
           cp -r ../kie-tools/packages/serverless-logic-web-tools/dist/* $DEPLOYMENT_DIR
-          git config --global user.email "kie-group-tools@googlegroups.com"
-          git config --global user.name "KIE Group Tools (kie-group-tools)"
           echo "Commit changes"
           git add . && git commit -m "Deploy ${{ inputs.tag }} (${{ inputs.environment }})" || echo "No changes."
 

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -111,8 +111,8 @@ jobs:
         id: commit_sha
         shell: bash
         run: |
-          mkdir -p ../kie-tools/packages/serverless-logic-web-tools/dist/
-          echo "ok" > ../kie-tools/packages/serverless-logic-web-tools/dist/testfile.txt
+          mkdir -p kie-tools/packages/serverless-logic-web-tools/dist/
+          echo "ok" > kie-tools/packages/serverless-logic-web-tools/dist/testfile.txt
 
       - name: "Checkout serverless-logic-sandbox-deployment"
         uses: actions/checkout@v3

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -70,13 +70,13 @@ jobs:
           echo "version=$(node -e "console.log(require('./package.json').version);")" >> $GITHUB_OUTPUT
         shell: bash
 
-      # - name: "Cache Maven packages"
-      #   if: github.event_name != 'pull_request'
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.m2
-      #     key: ${{ runner.os }}-kubesmarts_build_and_publish-m2-${{ hashFiles('**/pom.xml') }}
-      #     restore-keys: ${{ runner.os }}-kubesmarts_build_and_publish-m2
+      - name: "Cache Maven packages"
+        if: github.event_name != 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
       #
       # - name: "Setup environment"
       #   uses: ./kie-tools/.github/actions/setup-env

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -123,7 +123,6 @@ jobs:
           ref: gh-pages
 
       - name: "Update serverless-logic-sandbox-deployment resources"
-        if: ${{ !inputs.dry_run && github.event_name != 'pull_request' }}
         shell: bash
         run: |
           if [ "${{ inputs.environment }}" == "dev" ]; then
@@ -145,7 +144,21 @@ jobs:
           cp -r ../kie-tools/packages/serverless-logic-web-tools/dist/* $DEPLOYMENT_DIR
           git config --global user.email "kie-group-tools@googlegroups.com"
           git config --global user.name "KIE Group Tools (kie-group-tools)"
-          echo "Commit changes and push"
+          echo "Commit changes"
           git add . && git commit -m "Deploy ${{ inputs.tag }} (${{ inputs.environment }})" || echo "No changes."
+
+      - name: "Dry run: Git push"
+        if: ${{ inputs.dry_run || github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          echo "Dry run mode: Simulating git push"
+          cd serverless-logic-sandbox-deployment
+          git push --dry-run origin gh-pages
+
+      - name: "Git push"
+        if: ${{ !inputs.dry_run && github.event_name != 'pull_request' }}
+        shell: bash
+        run: |
+          echo "Pushing changes to gh-pages"
+          cd serverless-logic-sandbox-deployment
           git push origin gh-pages
-          cd -

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -1,0 +1,144 @@
+name: "Build and Publish"
+
+on:
+  workflow_call:
+    inputs:
+      dry_run:
+        type: boolean
+        required: true
+      environment:
+        description: Environment for the workflow (dev, staging, prod)
+        required: true
+        default: dev
+        type: string
+      tag:
+        type: string
+        required: false
+        default: main
+    secrets:
+      kie_group_tools_token:
+        required: false
+      gh_token:
+        required: false
+env:
+  SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO || 'kubesmarts/sandbox-deployment' }}
+  DASHBUILDER__viewerImageAccount: "kubesmarts"
+  DASHBUILDER__viewerImageName: "incubator-kie-dashbuilder-viewer"
+  DASHBUILDER__viewerImageRegistry: "quay.io"
+  KIE_TOOLS_BUILD__buildContainerImages: "false"
+  KIE_TOOLS_BUILD__runEndToEndTests: "false"
+  KIE_TOOLS_BUILD__runLinters: "false"
+  KIE_TOOLS_BUILD__runTests: "false"
+  SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount: "kubesmarts"
+  SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName: "incubator-kie-serverless-logic-web-tools-base-builder"
+  SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry: "quay.io"
+  SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageTag: "${{ inputs.tag }}"
+  SERVERLESS_LOGIC_WEB_TOOLS__buildInfo: ""
+  SERVERLESS_LOGIC_WEB_TOOLS__corsProxyUrl: ${{ (inputs.environment == 'dev' &&  'https://daily-dev-cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud' ) || (inputs.environment == 'staging' &&  'https://staging-cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud' ) || 'https://cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud' }}
+  SERVERLESS_LOGIC_WEB_TOOLS__dashbuilderViewerImageTag: "${{ inputs.tag }}"
+  SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryName: "sandbox-catalog"
+  SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryOrg: "kubesmarts"
+  SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef: "${{ inputs.tag }}"
+  SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount: "kubesmarts"
+  SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName: "incubator-kie-serverless-logic-web-tools-swf-builder"
+  SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry: "quay.io"
+  SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageTag: "${{ inputs.tag }}"
+  SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount: "kubesmarts"
+  SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName: "incubator-kie-serverless-logic-web-tools-swf-dev-mode"
+  SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry: "quay.io"
+  SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageTag: "${{ inputs.tag }}"
+  SERVERLESS_LOGIC_WEB_TOOLS__version: ${{ (inputs.environment == 'dev' && '0.0.0') || inputs.tag }}
+  WEBPACK__minimize: "true"
+  WEBPACK__tsLoaderTranspileOnly: "false"
+
+jobs:
+  build:
+    if: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Clone kie-tools"
+        uses: actions/checkout@v3
+        with:
+          path: kie-tools
+          ref: ${{ inputs.tag }}
+
+      # This bash script will set an output version for this step. It can be used with steps.version.outputs.version
+      - name: "Output version"
+        id: version
+        run: |
+          cd kie-tools
+          echo "version=$(node -e "console.log(require('./package.json').version);")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: "Cache Maven packages"
+        if: github.event_name != 'pull_request'
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-daily-dev-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-daily-dev-m2
+
+      - name: "Setup environment"
+        uses: ./kie-tools/.github/actions/setup-env
+        with:
+          working_dir: kie-tools
+
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          working_dir: kie-tools
+
+      - name: "Parse `commit_sha`"
+        id: commit_sha
+        shell: bash
+        run: |
+          cd kie-tools
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: "Build serverless-logic-web-tools"
+        run: |
+          if [ "${{ inputs.environment }}" = "dev" ]; then
+            export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ steps.version.outputs.version }} (daily-dev) @ ${{ steps.commit_sha.outputs.commit_sha }}"
+          elif [ "${{ inputs.environment }}" = "staging" ]; then
+            export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ inputs.tag }} (staging) @ ${{ steps.commit_sha.outputs.commit_sha }}"
+          fi
+          echo "SERVERLESS_LOGIC_WEB_TOOLS__buildInfo=$SERVERLESS_LOGIC_WEB_TOOLS__buildInfo"
+          cd kie-tools
+          pnpm -F @kie-tools/serverless-logic-web-tools... build:prod
+
+      - name: "Checkout serverless-logic-sandbox-deployment"
+        uses: actions/checkout@v3
+        with:
+          token: ${{ github.event_name != 'pull_request' && secrets.KIE_GROUP_TOOLS_TOKEN || secrets.GITHUB_TOKEN }}
+          path: serverless-logic-sandbox-deployment
+          repository: ${{ env.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
+          ref: gh-pages
+
+      - name: "Update serverless-logic-sandbox-deployment resources"
+        if: ${{ !inputs.dry_run && github.event_name != 'pull_request' }}
+        shell: bash
+        run: |
+          if [ "${{ inputs.environment }}" == "dev" ]; then
+            export DEPLOYMENT_DIR="dev"
+          elif [ "${{ inputs.environment }}" == "staging" ]; then
+            export DEPLOYMENT_DIR="staging/${{ inputs.tag }}"
+          else
+            export DEPLOYMENT_DIR="."
+          fi
+          echo "DEPLOYMENT_DIR=$DEPLOYMENT_DIR"
+          cd serverless-logic-sandbox-deployment
+          shopt -s extglob
+          if [ "${{ inputs.environment }}" == "prod" ]; then
+            rm -rf -- !("dev"|"staging"|".nojekyll"|"CNAME"|"0.25.0"|"schemas")
+          else
+            rm -rf $DEPLOYMENT_DIR
+            mkdir -p $DEPLOYMENT_DIR
+          fi
+          cp -r ../kie-tools/packages/serverless-logic-web-tools/dist/* $DEPLOYMENT_DIR
+          git config --global user.email "kie-group-tools@googlegroups.com"
+          git config --global user.name "KIE Group Tools (kie-group-tools)"
+          echo "Commit changes and push"
+          git add . && git commit -m "Deploy ${{ inputs.tag }} (${{ inputs.environment }})" || echo "No changes."
+          git push origin gh-pages
+          cd -

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -70,42 +70,49 @@ jobs:
           echo "version=$(node -e "console.log(require('./package.json').version);")" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: "Cache Maven packages"
-        if: github.event_name != 'pull_request'
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-kubesmarts_build_and_publish-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-kubesmarts_build_and_publish-m2
+      # - name: "Cache Maven packages"
+      #   if: github.event_name != 'pull_request'
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ~/.m2
+      #     key: ${{ runner.os }}-kubesmarts_build_and_publish-m2-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: ${{ runner.os }}-kubesmarts_build_and_publish-m2
+      #
+      # - name: "Setup environment"
+      #   uses: ./kie-tools/.github/actions/setup-env
+      #   with:
+      #     working_dir: kie-tools
+      #
+      # - name: "Bootstrap"
+      #   id: bootstrap
+      #   uses: ./kie-tools/.github/actions/bootstrap
+      #   with:
+      #     working_dir: kie-tools
+      #
+      # - name: "Parse `commit_sha`"
+      #   id: commit_sha
+      #   shell: bash
+      #   run: |
+      #     cd kie-tools
+      #     echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      #
+      # - name: "Build serverless-logic-web-tools"
+      #   run: |
+      #     if [ "${{ inputs.environment }}" = "dev" ]; then
+      #       export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ steps.version.outputs.version }} (daily-dev) @ ${{ steps.commit_sha.outputs.commit_sha }}"
+      #     elif [ "${{ inputs.environment }}" = "staging" ]; then
+      #       export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ inputs.tag }} (staging) @ ${{ steps.commit_sha.outputs.commit_sha }}"
+      #     fi
+      #     echo "SERVERLESS_LOGIC_WEB_TOOLS__buildInfo=$SERVERLESS_LOGIC_WEB_TOOLS__buildInfo"
+      #     cd kie-tools
+      #     pnpm -F @kie-tools/serverless-logic-web-tools... build:prod
 
-      - name: "Setup environment"
-        uses: ./kie-tools/.github/actions/setup-env
-        with:
-          working_dir: kie-tools
-
-      - name: "Bootstrap"
-        id: bootstrap
-        uses: ./kie-tools/.github/actions/bootstrap
-        with:
-          working_dir: kie-tools
-
-      - name: "Parse `commit_sha`"
+      - name: "Write testfile.txt"
         id: commit_sha
         shell: bash
         run: |
-          cd kie-tools
-          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-      - name: "Build serverless-logic-web-tools"
-        run: |
-          if [ "${{ inputs.environment }}" = "dev" ]; then
-            export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ steps.version.outputs.version }} (daily-dev) @ ${{ steps.commit_sha.outputs.commit_sha }}"
-          elif [ "${{ inputs.environment }}" = "staging" ]; then
-            export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${{ inputs.tag }} (staging) @ ${{ steps.commit_sha.outputs.commit_sha }}"
-          fi
-          echo "SERVERLESS_LOGIC_WEB_TOOLS__buildInfo=$SERVERLESS_LOGIC_WEB_TOOLS__buildInfo"
-          cd kie-tools
-          pnpm -F @kie-tools/serverless-logic-web-tools... build:prod
+          mkdir -p ../kie-tools/packages/serverless-logic-web-tools/dist/
+          echo "ok" > ../kie-tools/packages/serverless-logic-web-tools/dist/testfile.txt
 
       - name: "Checkout serverless-logic-sandbox-deployment"
         uses: actions/checkout@v3

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -1,4 +1,4 @@
-name: "Build and Publish"
+name: "Kubesmarts :: Build and Publish"
 
 on:
   workflow_call:

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -57,11 +57,6 @@ jobs:
     if: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO != '' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Git Environment
-        run: |
-          git config --global user.name "${{ secrets.KIE1_USER_NAME }}"
-          git config --global user.email "${{ secrets.KIE1_EMAIL }}"
-
       - name: "Clone kie-tools"
         uses: actions/checkout@v3
         with:
@@ -148,6 +143,8 @@ jobs:
             mkdir -p $DEPLOYMENT_DIR
           fi
           cp -r ../kie-tools/packages/serverless-logic-web-tools/dist/* $DEPLOYMENT_DIR
+          git config --global user.name "${{ secrets.KIE1_USER_NAME }}"
+          git config --global user.email "${{ secrets.KIE1_EMAIL }}"
           echo "Commit changes"
           git add . && git commit -m "Deploy ${{ inputs.tag }} (${{ inputs.environment }})" || echo "No changes."
 

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -16,10 +16,12 @@ on:
         required: false
         default: main
     secrets:
-      kie_group_tools_token:
-        required: false
-      gh_token:
-        required: false
+      KIE1_TOKEN:
+        required: true
+      KIE1_USER_NAME:
+        required: true
+      KIE1_EMAIL:
+        required: true
 env:
   SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO || 'kubesmarts/sandbox-deployment' }}
   DASHBUILDER__viewerImageAccount: "kubesmarts"

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: "Cache Maven packages"
         if: github.event_name != 'pull_request'
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-daily-dev-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -75,8 +75,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-daily-dev-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-daily-dev-m2
+          key: ${{ runner.os }}-kubesmarts_build_and_publish-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-kubesmarts_build_and_publish-m2
 
       - name: "Setup environment"
         uses: ./kie-tools/.github/actions/setup-env

--- a/.github/workflows/kubesmarts_custom_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_custom_build_and_publish.yml
@@ -1,4 +1,4 @@
-name: "Custom version :: Build and Publish"
+name: "Kubesmarts :: Custom version :: Build and Publish"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/kubesmarts_custom_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_custom_build_and_publish.yml
@@ -1,0 +1,31 @@
+name: "Custom version :: Build and Publish"
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+      environment:
+        description: Environment for the workflow (dev, staging, prod)
+        required: true
+        default: dev
+      tag:
+        description: Tag to build
+        required: false
+        default: main
+
+concurrency:
+  group: kubesmarts-custom-build-publish-${{ github.event.inputs.environment }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_publish:
+    uses: ./.github/workflows/kubesmarts_build_and_publish.yml
+    with:
+      dry_run: ${{ fromJSON(github.event.inputs.dry_run) }}
+      environment: ${{ github.event.inputs.environment }}
+      tag: ${{ github.event.inputs.tag }}
+    secrets:
+      kie_group_tools_token: ${{ secrets.KIE_GROUP_TOOLS_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kubesmarts_custom_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_custom_build_and_publish.yml
@@ -27,5 +27,6 @@ jobs:
       environment: ${{ github.event.inputs.environment }}
       tag: ${{ github.event.inputs.tag }}
     secrets:
-      kie_group_tools_token: ${{ secrets.KIE_GROUP_TOOLS_TOKEN }}
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      KIE1_TOKEN: ${{ secrets.KIE1_TOKEN }}
+      KIE1_EMAIL: ${{ secrets.KIE1_EMAIL }}
+      KIE1_USER_NAME: ${{ secrets.KIE1_USER_NAME }}

--- a/.github/workflows/kubesmarts_daily_dev_publish.yml
+++ b/.github/workflows/kubesmarts_daily_dev_publish.yml
@@ -1,0 +1,21 @@
+name: "Daily dev :: Publish"
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # 4am UTC everyday
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/kubesmarts_daily_dev_publish.yml"
+      - ".github/workflows/kubesmarts_build_and_publish.yml"
+
+jobs:
+  build_and_publish:
+    uses: ./.github/workflows/kubesmarts_build_and_publish.yml
+    with:
+      dry_run: false
+      environment: dev
+      tag: main
+    secrets:
+      kie_group_tools_token: ${{ secrets.KIE_GROUP_TOOLS_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kubesmarts_daily_dev_publish.yml
+++ b/.github/workflows/kubesmarts_daily_dev_publish.yml
@@ -17,5 +17,6 @@ jobs:
       environment: dev
       tag: main
     secrets:
-      kie_group_tools_token: ${{ secrets.KIE_GROUP_TOOLS_TOKEN }}
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      KIE1_TOKEN: ${{ secrets.KIE1_TOKEN }}
+      KIE1_EMAIL: ${{ secrets.KIE1_EMAIL }}
+      KIE1_USER_NAME: ${{ secrets.KIE1_USER_NAME }}

--- a/.github/workflows/kubesmarts_daily_dev_publish.yml
+++ b/.github/workflows/kubesmarts_daily_dev_publish.yml
@@ -1,4 +1,4 @@
-name: "Daily dev :: Publish"
+name: "Kubesmarts :: Daily dev :: Publish"
 
 on:
   schedule:


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/SRVLOGIC-511

**Description:**
Have the application to be deployed via our Kubesmarts fork with GHA.
We can have a weekly build after the upstream sync (at /dev)
The GH Workflow to syn start.kubesmarts.org is:
https://github.com/kiegroup/serverless-logic-sandbox-deployment/blob/main/.github/workflows/daily_dev_publish.yml
