### PR TITLE
NO-ISSUE: Add repo vars to enable or disable osl_sync_main

### DIFF
--- a/.github/workflows/osl_sync_main.yml
+++ b/.github/workflows/osl_sync_main.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   sync_main_apache:
+    if: ${{ vars.ENABLE_OSL_SYNC_MAIN == 'yes' }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
This PR introduces a new repo var `ENABLE_OSL_SYNC_MAIN`. Only if `yes` the CI is executed and the CI will not be executed by forks unintentionally.

See: https://github.com/kubesmarts/kie-tools/pull/63#issuecomment-2647713622