### PR TITLE
SRVLOGIC-528: do not use mvnw --version during the build as it does some internet connection and fail the build on OSBS

### DIFF
--- a/packages/osl-swf-builder-image/generated/modules/kogito-maven/common/configure
+++ b/packages/osl-swf-builder-image/generated/modules/kogito-maven/common/configure
@@ -38,8 +38,6 @@ else
     echo "---> Installing Maven wrapper for Maven 3.8.6"
     cd "${MAVEN_HOME}"/bin
     cp -rpTv "${SCRIPT_DIR}"/maven-wrapper/ .
-    echo "--> Validating Maven wrapper installation"
-    ${MAVEN_CMD} --version
 fi
 
 mkdir "${KOGITO_HOME}"/.m2

--- a/packages/osl-swf-devmode-image/generated/modules/kogito-maven/common/configure
+++ b/packages/osl-swf-devmode-image/generated/modules/kogito-maven/common/configure
@@ -38,8 +38,6 @@ else
     echo "---> Installing Maven wrapper for Maven 3.8.6"
     cd "${MAVEN_HOME}"/bin
     cp -rpTv "${SCRIPT_DIR}"/maven-wrapper/ .
-    echo "--> Validating Maven wrapper installation"
-    ${MAVEN_CMD} --version
 fi
 
 mkdir "${KOGITO_HOME}"/.m2

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/configure
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/configure
@@ -38,8 +38,6 @@ else
     echo "---> Installing Maven wrapper for Maven 3.8.6"
     cd "${MAVEN_HOME}"/bin
     cp -rpTv "${SCRIPT_DIR}"/maven-wrapper/ .
-    echo "--> Validating Maven wrapper installation"
-    ${MAVEN_CMD} --version
 fi
 
 mkdir "${KOGITO_HOME}"/.m2


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVLOGIC-528

The `${MAVEN_CMD} --version`  tries to download the `.mvn/wrapper/maven-wrapper.jar` and the OSBS fails with:

```
 + /usr/share/maven/bin/mvnw --version
INFO - Exception in thread "main" java.net.ConnectException: Connection refused
```
So I'm proposing to drop it as we already included the maven-wrapper.jar as part of PR https://github.com/kubesmarts/kie-tools/pull/67.

To make sure it is working, I built a swf-builder image with this change and then:
```
podman run -it localhost/openshift-serverless-1/logic-swf-builder-rhel8:latest bash
${MAVEN_CMD} clean install
```

the build of the `serverless-workflow-project` worked fine inside the image.