### PR TITLE
[9.103.x-prod] SRVLOGIC-572: Cleanup outdated knative revisions only if the workflow has, or inherit from the SFP, a Sink configuration

### DIFF
--- a/packages/sonataflow-operator/internal/controller/profiles/common/utils.go
+++ b/packages/sonataflow-operator/internal/controller/profiles/common/utils.go
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/rest"
+
+	operatorapi "github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api/v1alpha08"
+	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/internal/controller/knative"
+	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/internal/controller/platform"
+	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/utils"
+)
+
+// CleanupOutdatedRevisions helper function to remove the outdated revisions for a workflow deployed with the knative
+// deploymentMode.
+// TODO: Refactor when we can remove dependency between properties.go -> knative.go, and k8s.go -> knative.go.
+func CleanupOutdatedRevisions(ctx context.Context, cfg *rest.Config, workflow *operatorapi.SonataFlow) error {
+	sfp, err := platform.GetActivePlatform(ctx, utils.GetClient(), workflow.Namespace, false)
+	if err != nil {
+		return fmt.Errorf("failed to get active platform to clean workflow outdated revisions, workflow: %s, namespace: %s : %v", workflow.Name, workflow.Namespace, err)
+	}
+	if err := knative.CleanupOutdatedRevisions(ctx, cfg, workflow, sfp); err != nil {
+		return fmt.Errorf("failed to cleanup workflow outdated revisions, workflow: %s, namespace: %s - %v", workflow.Name, workflow.Namespace, err)
+	}
+	return nil
+}

--- a/packages/sonataflow-operator/internal/controller/profiles/gitops/states_gitops.go
+++ b/packages/sonataflow-operator/internal/controller/profiles/gitops/states_gitops.go
@@ -19,9 +19,6 @@ package gitops
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/internal/controller/knative"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,8 +70,5 @@ func (f *followDeployWorkflowState) Do(ctx context.Context, workflow *operatorap
 
 func (f *followDeployWorkflowState) PostReconcile(ctx context.Context, workflow *operatorapi.SonataFlow) error {
 	// Clean up the outdated Knative revisions, if any
-	if err := knative.CleanupOutdatedRevisions(ctx, f.Cfg, workflow); err != nil {
-		return fmt.Errorf("failied to cleanup workflow outdated revisions, workflow: %s, namespace: %s - %v", workflow.Name, workflow.Namespace, err)
-	}
-	return nil
+	return common.CleanupOutdatedRevisions(ctx, f.Cfg, workflow)
 }

--- a/packages/sonataflow-operator/internal/controller/profiles/preview/states_preview.go
+++ b/packages/sonataflow-operator/internal/controller/profiles/preview/states_preview.go
@@ -35,7 +35,6 @@ import (
 	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api"
 	operatorapi "github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api/v1alpha08"
 	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/internal/controller/builder"
-	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/internal/controller/knative"
 	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/internal/controller/platform"
 	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/internal/controller/profiles/common"
 	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/internal/controller/profiles/common/constants"
@@ -229,10 +228,7 @@ func (h *deployWithBuildWorkflowState) Do(ctx context.Context, workflow *operato
 
 func (h *deployWithBuildWorkflowState) PostReconcile(ctx context.Context, workflow *operatorapi.SonataFlow) error {
 	// Clean up the outdated Knative revisions, if any
-	if err := knative.CleanupOutdatedRevisions(ctx, h.Cfg, workflow); err != nil {
-		return fmt.Errorf("failied to cleanup workflow outdated revisions, workflow: %s, namespace: %s - %v", workflow.Name, workflow.Namespace, err)
-	}
-	return nil
+	return common.CleanupOutdatedRevisions(ctx, h.Cfg, workflow)
 }
 
 // isWorkflowChanged checks whether the contents of .spec.flow of the given workflow has changed.


### PR DESCRIPTION
    - incubator-kie-tools-3072: [sonataflow-operator] Cleanup outdated knative revisions only if the workflow has, or inherit from the SFP, a Sink configuration (#3073)

(cherry picked from commit d3f639fefb6eedf15945e5898754234b862bddd5)