### PR TITLE
[SRVLOGIC-597] Change vars to publish bundle and catalog to Quay.io

### DIFF
--- a/_osl/osl.env
+++ b/_osl/osl.env
@@ -5,29 +5,29 @@
 # set +a
 
 # Use digests to update the manifests accordingly
-USE_IMAGE_DIGESTS=true
+USE_IMAGE_DIGESTS=false
 # Won't build any images in this repo, just the manifests. The images are built within internal systems.
 KIE_TOOLS_BUILD__buildContainerImages=false
 
 # SHA required for the operator image. If you don't have it yet, just comment it.
-OSL_OPERATOR_IMAGE__buildTag=sha256:ffae74d76431b428341abfe8b8b704323261c224ff9140a2ea2782c0524f222f
+OSL_OPERATOR_IMAGE__buildTag=9.103.x-prod
 
-SONATAFLOW_OPERATOR__registry=registry.redhat.io
-SONATAFLOW_OPERATOR__account=openshift-serverless-1
-SONATAFLOW_OPERATOR__name=openshift-serverless-1-logic-rhel8-operator
-SONATAFLOW_OPERATOR__buildTag=sha256:ffae74d76431b428341abfe8b8b704323261c224ff9140a2ea2782c0524f222f
+SONATAFLOW_OPERATOR__registry=quay.io
+SONATAFLOW_OPERATOR__account=kubesmarts
+SONATAFLOW_OPERATOR__name=incubator-kie-sonataflow-operator
+SONATAFLOW_OPERATOR__buildTag=9.103.x-prod
 
-SONATAFLOW_OPERATOR__kogitoDataIndexPostgresqlImage=registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.36.0
-SONATAFLOW_OPERATOR__kogitoDataIndexEphemeralImage=registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.36.0
-SONATAFLOW_OPERATOR__kogitoJobsServicePostgresqlImage=registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel8:1.36.0
-SONATAFLOW_OPERATOR__kogitoJobsServiceEphemeralImage=registry.redhat.io/openshift-serverless-1/logic-jobs-service-ephemeral-rhel8:1.36.0
-SONATAFLOW_OPERATOR__sonataflowDevModeImage=registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:1.36.0
-SONATAFLOW_OPERATOR__sonataflowBuilderImage=registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.36.0
-SONATAFLOW_OPERATOR__kogitoDBMigratorToolImage=registry.redhat.io/openshift-serverless-1/logic-db-migrator-tool-rhel8:1.36.0
+SONATAFLOW_OPERATOR__kogitoDataIndexPostgresqlImage=quay.io/kubesmarts/logic-data-index-postgresql-rhel8:9.103.x-prod
+SONATAFLOW_OPERATOR__kogitoDataIndexEphemeralImage=quay.io/kubesmarts/incubator-kie-kogito-data-index-ephemeral:9.103.x-prod
+SONATAFLOW_OPERATOR__kogitoJobsServicePostgresqlImage=quay.io/kubesmarts/incubator-kie-kogito-data-index-postgresql:9.103.x-prod
+SONATAFLOW_OPERATOR__kogitoJobsServiceEphemeralImage=quay.io/kubesmarts/incubator-kie-kogito-jobs-service-ephemeral:9.103.x-prod
+SONATAFLOW_OPERATOR__sonataflowDevModeImage=quay.io/kubesmarts/incubator-kie-sonataflow-devmode:9.103.x-prod
+SONATAFLOW_OPERATOR__sonataflowBuilderImage=quay.io/kubesmarts/incubator-kie-sonataflow-builder:9.103.x-prod
+SONATAFLOW_OPERATOR__kogitoDBMigratorToolImage=quay.io/kubesmarts/kie-kogito-db-migrator-tool:9.103.x-prod
 
 # If Drools version is different, set the Drools version manually in the `maven-base/pom.xml`
-KOGITO_RUNTIME_version=9.103.0.redhat-00003
-SONATAFLOW_DEVMODE_IMAGE__sonataflowQuarkusDevUiVersion=9.103.0.redhat-00003
-SONATAFLOW_QUARKUS_DEVUI_VERSION=9.103.0.redhat-00003
-QUARKUS_PLATFORM_version=3.15.4.redhat-00001
-KOGITO_IMAGES_CEKIT_MODULES__quarkusGroupId=com.redhat.quarkus.platform
+KOGITO_RUNTIME_version=999-20250504-SNAPSHOT
+SONATAFLOW_DEVMODE_IMAGE__sonataflowQuarkusDevUiVersion=3.15.3.1
+SONATAFLOW_QUARKUS_DEVUI_VERSION=3.15.3.1
+QUARKUS_PLATFORM_version=3.15.3.1
+KOGITO_IMAGES_CEKIT_MODULES__quarkusGroupId=io.quarkus.platform

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -123,11 +123,11 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>9.103.0.redhat-00003</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20250504-SNAPSHOT</version.org.kie.kogito>
     <version.org.drools>9.103.0.redhat-00002</version.org.drools>
 
     <!-- Quarkus -->
-    <version.quarkus>3.15.4.redhat-00001</version.quarkus>
+    <version.quarkus>3.15.3.1</version.quarkus>
 
     <!-- 3rd party dependencies -->
     <version.junit>4.13.2</version.junit>

--- a/packages/sonataflow-operator/Makefile
+++ b/packages/sonataflow-operator/Makefile
@@ -342,7 +342,7 @@ bundle: kustomize install-operator-sdk ## Generate bundle manifests and metadata
 .PHONY: bundle-build
 BUNDLE_DESCRIPTOR = "images/bundle.yaml"
 bundle-build: ## Build the bundle image
-	cekit -v --descriptor $(BUNDLE_DESCRIPTOR) build ${build_options} $(BUILDER) --no-squash --build-arg SOURCE_DATE_EPOCH="$(shell git log -1 --pretty=%ct)"
+	cekit -v --descriptor $(BUNDLE_DESCRIPTOR) build ${build_options} $(BUILDER) --no-squash --platform=linux/amd64 --build-arg SOURCE_DATE_EPOCH="$(shell git log -1 --pretty=%ct)"
 ifneq ($(ignore_tag),true)
 	$(BUILDER) tag sonataflow-operator-bundle:latest $(BUNDLE_IMG)
 endif

--- a/packages/sonataflow-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/packages/sonataflow-operator/config/default/manager_auth_proxy_patch.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/packages/sonataflow-operator/config/manager/SonataFlow-Builder.containerfile
+++ b/packages/sonataflow-operator/config/manager/SonataFlow-Builder.containerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.36.0 AS builder
+FROM quay.io/kubesmarts/incubator-kie-sonataflow-builder:9.103.x-prod AS builder
 
 # variables that can be overridden by the builder
 # To add a Quarkus extension to your application

--- a/packages/sonataflow-operator/config/manager/controllers_cfg.yaml
+++ b/packages/sonataflow-operator/config/manager/controllers_cfg.yaml
@@ -25,13 +25,13 @@ kanikoDefaultWarmerImageTag: gcr.io/kaniko-project/warmer:v1.9.0
 # Default image used internally by the Operator Managed Kaniko builder to create the executor pods
 kanikoExecutorImageTag: gcr.io/kaniko-project/executor:v1.9.0
 # The Jobs Service image to use, if empty the operator will use the default Apache Community one based on the current operator's version
-jobsServicePostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel8:1.36.0"
-jobsServiceEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-ephemeral-rhel8:1.36.0"
+jobsServicePostgreSQLImageTag: "quay.io/kubesmarts/incubator-kie-kogito-data-index-postgresql:9.103.x-prod"
+jobsServiceEphemeralImageTag: "quay.io/kubesmarts/incubator-kie-kogito-jobs-service-ephemeral:9.103.x-prod"
 # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
-dataIndexPostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.36.0"
-dataIndexEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.36.0"
+dataIndexPostgreSQLImageTag: "quay.io/kubesmarts/logic-data-index-postgresql-rhel8:9.103.x-prod"
+dataIndexEphemeralImageTag: "quay.io/kubesmarts/incubator-kie-kogito-data-index-ephemeral:9.103.x-prod"
 # The Kogito PostgreSQL DB Migrator image to use (TBD: to replace with apache image)
-dbMigratorToolImageTag: "registry.redhat.io/openshift-serverless-1/logic-db-migrator-tool-rhel8:1.36.0"
+dbMigratorToolImageTag: "quay.io/kubesmarts/kie-kogito-db-migrator-tool:9.103.x-prod"
 # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
 # Order of precedence is:
 # 1. SonataFlowPlatform in the given namespace
@@ -39,18 +39,18 @@ dbMigratorToolImageTag: "registry.redhat.io/openshift-serverless-1/logic-db-migr
 # 3. The FROM in the Dockerfile in the operator's namespace "sonataflow-operator-builder-config" configMap.
 # If 1 or 2, the FROM tag will be replaced by the tag se there.
 # If empty the operator will use the default Apache Community one based on the current operator's version.
-sonataFlowBaseBuilderImageTag: "registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.36.0"
+sonataFlowBaseBuilderImageTag: "quay.io/kubesmarts/incubator-kie-sonataflow-builder:9.103.x-prod"
 # The image to use to deploy SonataFlow workflow images in devmode profile.
 # If empty the operator will use the default Apache Community one based on the current operator's version.
-sonataFlowDevModeImageTag: "registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:1.36.0"
+sonataFlowDevModeImageTag: "quay.io/kubesmarts/incubator-kie-sonataflow-devmode:9.103.x-prod"
 # The default name of the builder configMap in the operator's namespace
 builderConfigMapName: "logic-operator-rhel8-builder-config"
 # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
 # in cases where the workflow being built has configured postgresql persistence.
 postgreSQLPersistenceExtensions:
-  - groupId: com.redhat.quarkus.platform
+  - groupId: io.quarkus.platform
     artifactId: quarkus-jdbc-postgresql
-  - groupId: com.redhat.quarkus.platform
+  - groupId: io.quarkus.platform
     artifactId: quarkus-agroal
   - groupId: org.kie
     artifactId: kie-addons-quarkus-persistence-jdbc

--- a/packages/sonataflow-operator/config/manager/kustomization.yaml
+++ b/packages/sonataflow-operator/config/manager/kustomization.yaml
@@ -39,9 +39,9 @@ kind:
   Kustomization
   # Changed during "make build", do not attempt to modify it manually!
 images:
-  - digest: sha256:ffae74d76431b428341abfe8b8b704323261c224ff9140a2ea2782c0524f222f
-    name: controller
-    newName: registry.redhat.io/openshift-serverless-1/openshift-serverless-1-logic-rhel8-operator
+  - name: controller
+    newName: quay.io/kubesmarts/incubator-kie-sonataflow-operator
+    newTag: 9.103.x-prod
 # Patching the manager deployment file to add an env var with the operator namespace in
 patches:
   - patch: |-

--- a/packages/sonataflow-operator/operator.yaml
+++ b/packages/sonataflow-operator/operator.yaml
@@ -28178,7 +28178,7 @@ data:
     under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES
     OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for
     the\n# specific language governing permissions and limitations\n# under the License.\n\nFROM
-    registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.36.0 AS builder\n\n#
+    quay.io/kubesmarts/incubator-kie-sonataflow-builder:9.103.x-prod AS builder\n\n#
     variables that can be overridden by the builder\n# To add a Quarkus extension
     to your application\nARG QUARKUS_EXTENSIONS\n# Args to pass to the Quarkus CLI
     add extension command\nARG QUARKUS_ADD_EXTENSION_ARGS\n# Additional java/mvn arguments
@@ -28230,13 +28230,13 @@ data:
     # Default image used internally by the Operator Managed Kaniko builder to create the executor pods
     kanikoExecutorImageTag: gcr.io/kaniko-project/executor:v1.9.0
     # The Jobs Service image to use, if empty the operator will use the default Apache Community one based on the current operator's version
-    jobsServicePostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel8:1.36.0"
-    jobsServiceEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-ephemeral-rhel8:1.36.0"
+    jobsServicePostgreSQLImageTag: "quay.io/kubesmarts/incubator-kie-kogito-data-index-postgresql:9.103.x-prod"
+    jobsServiceEphemeralImageTag: "quay.io/kubesmarts/incubator-kie-kogito-jobs-service-ephemeral:9.103.x-prod"
     # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
-    dataIndexPostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.36.0"
-    dataIndexEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.36.0"
+    dataIndexPostgreSQLImageTag: "quay.io/kubesmarts/logic-data-index-postgresql-rhel8:9.103.x-prod"
+    dataIndexEphemeralImageTag: "quay.io/kubesmarts/incubator-kie-kogito-data-index-ephemeral:9.103.x-prod"
     # The Kogito PostgreSQL DB Migrator image to use (TBD: to replace with apache image)
-    dbMigratorToolImageTag: "registry.redhat.io/openshift-serverless-1/logic-db-migrator-tool-rhel8:1.36.0"
+    dbMigratorToolImageTag: "quay.io/kubesmarts/kie-kogito-db-migrator-tool:9.103.x-prod"
     # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
     # Order of precedence is:
     # 1. SonataFlowPlatform in the given namespace
@@ -28244,18 +28244,18 @@ data:
     # 3. The FROM in the Dockerfile in the operator's namespace "sonataflow-operator-builder-config" configMap.
     # If 1 or 2, the FROM tag will be replaced by the tag se there.
     # If empty the operator will use the default Apache Community one based on the current operator's version.
-    sonataFlowBaseBuilderImageTag: "registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.36.0"
+    sonataFlowBaseBuilderImageTag: "quay.io/kubesmarts/incubator-kie-sonataflow-builder:9.103.x-prod"
     # The image to use to deploy SonataFlow workflow images in devmode profile.
     # If empty the operator will use the default Apache Community one based on the current operator's version.
-    sonataFlowDevModeImageTag: "registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:1.36.0"
+    sonataFlowDevModeImageTag: "quay.io/kubesmarts/incubator-kie-sonataflow-devmode:9.103.x-prod"
     # The default name of the builder configMap in the operator's namespace
     builderConfigMapName: "logic-operator-rhel8-builder-config"
     # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
     # in cases where the workflow being built has configured postgresql persistence.
     postgreSQLPersistenceExtensions:
-      - groupId: com.redhat.quarkus.platform
+      - groupId: io.quarkus.platform
         artifactId: quarkus-jdbc-postgresql
-      - groupId: com.redhat.quarkus.platform
+      - groupId: io.quarkus.platform
         artifactId: quarkus-agroal
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc
@@ -28322,7 +28322,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: registry.redhat.io/openshift-serverless-1/openshift-serverless-1-logic-rhel8-operator@sha256:ffae74d76431b428341abfe8b8b704323261c224ff9140a2ea2782c0524f222f
+          image: quay.io/kubesmarts/incubator-kie-sonataflow-operator:9.103.x-prod
           livenessProbe:
             httpGet:
               path: /healthz
@@ -28357,7 +28357,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/packages/sonataflow-operator/version/version.go
+++ b/packages/sonataflow-operator/version/version.go
@@ -20,7 +20,7 @@ package version
 // Don't change it manually, use the make bump-version <version>
 const operatorVersion = "1.36.0"
 
-const tagVersion = "1.36.0"
+const tagVersion = "9.103.x-prod"
 
 // GetOperatorVersion gets the current operator version
 func GetOperatorVersion() string {


### PR DESCRIPTION
Just a reference for https://issues.redhat.com/browse/SRVLOGIC-597, do not merge it.

Images published:

- quay.io/repository/kubesmarts/incubator-kie-sonataflow-operator-bundle:v9.103.x-prod
- quay.io/repository/kubesmarts/incubator-kie-sonataflow-operator-catalog:v9.103.x-prod

`CatalogSource` for reference:

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata: 
  name: sonataflow-operator-catalog
  namespace: openshift-marketplace  # Or 'olm' for vanilla Kubernetes
spec: 
  sourceType: grpc
  image: quay.io/kubesmarts/incubator-kie-sonataflow-operator-catalog:v9.103.x-prod
  displayName: SonataFlow Operator Catalog
  publisher: Apache
```