### PR TITLE
[9.103.x-prod][SRVLOGIC-599] - Fix default Quarkus namespace on bundle configMaps

### DIFF
--- a/packages/osl-operator-bundle-image/generated/bundle/manifests/logic-operator-rhel8-controllers-config_v1_configmap.yaml
+++ b/packages/osl-operator-bundle-image/generated/bundle/manifests/logic-operator-rhel8-controllers-config_v1_configmap.yaml
@@ -51,9 +51,9 @@ data:
     # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
     # in cases where the workflow being built has configured postgresql persistence.
     postgreSQLPersistenceExtensions:
-      - groupId: com.redhat.quarkus.platform
+      - groupId: io.quarkus
         artifactId: quarkus-jdbc-postgresql
-      - groupId: com.redhat.quarkus.platform
+      - groupId: io.quarkus
         artifactId: quarkus-agroal
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc

--- a/packages/osl-operator-bundle-image/generated/bundle/manifests/logic-operator-rhel8.clusterserviceversion.yaml
+++ b/packages/osl-operator-bundle-image/generated/bundle/manifests/logic-operator-rhel8.clusterserviceversion.yaml
@@ -120,7 +120,7 @@ metadata:
     capabilities: Basic Install
     categories: Application Runtime
     certified: "false"
-    createdAt: "2025-05-22T13:43:57Z"
+    createdAt: "2025-05-22T22:11:11Z"
     description: OpenShift Serverless Logic Kubernetes Operator for deploying workflow applications based on the CNCF Serverless Workflow specification
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "false"

--- a/packages/sonataflow-operator/config/manager/controllers_cfg.yaml
+++ b/packages/sonataflow-operator/config/manager/controllers_cfg.yaml
@@ -48,9 +48,9 @@ builderConfigMapName: "logic-operator-rhel8-builder-config"
 # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
 # in cases where the workflow being built has configured postgresql persistence.
 postgreSQLPersistenceExtensions:
-  - groupId: com.redhat.quarkus.platform
+  - groupId: io.quarkus
     artifactId: quarkus-jdbc-postgresql
-  - groupId: com.redhat.quarkus.platform
+  - groupId: io.quarkus
     artifactId: quarkus-agroal
   - groupId: org.kie
     artifactId: kie-addons-quarkus-persistence-jdbc

--- a/packages/sonataflow-operator/images/requirements.txt
+++ b/packages/sonataflow-operator/images/requirements.txt
@@ -12,11 +12,7 @@ elementpath==4.4.0
 pyyaml==6.0.1
 ruamel.yaml==0.18.6
 python-dateutil==2.9.0.post0
-<<<<<<< HEAD
-Jinja2==3.1.5
-=======
 Jinja2==3.1.6
->>>>>>> upstream/main
 pykwalify==1.8.0
 colorlog==6.8.2
 click==8.1.7

--- a/packages/sonataflow-operator/operator.yaml
+++ b/packages/sonataflow-operator/operator.yaml
@@ -28253,9 +28253,9 @@ data:
     # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
     # in cases where the workflow being built has configured postgresql persistence.
     postgreSQLPersistenceExtensions:
-      - groupId: com.redhat.quarkus.platform
+      - groupId: io.quarkus
         artifactId: quarkus-jdbc-postgresql
-      - groupId: com.redhat.quarkus.platform
+      - groupId: io.quarkus
         artifactId: quarkus-agroal
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc


### PR DESCRIPTION
See https://issues.redhat.com/browse/SRVLOGIC-599

@saumya1singh after merging this PR, you can run the `cekit` command directly using the `generated` dir in the `osl-operator-bundle` package.