### PR TITLE
SRVLOGIC-643: Create /app directory for management console

### DIFF
--- a/packages/osl-management-console-image/resources/modules/osl-management-console/configure-osl.sh
+++ b/packages/osl-management-console-image/resources/modules/osl-management-console/configure-osl.sh
@@ -26,6 +26,9 @@ MGMT_CONSOLE_HOME="${KOGITO_HOME}/management-console"
 cp -v "${SCRIPT_DIR}/added/EnvJson.schema.json" "${MGMT_CONSOLE_HOME}"
 cp -v "${SCRIPT_DIR}/added/image-env-to-json-linux-amd64" "${MGMT_CONSOLE_HOME}"
 
+# Create a directory for webapp
+mkdir "${MGMT_CONSOLE_HOME}/app"
+
 # Unzip the app
 cd "${MGMT_CONSOLE_HOME}/app"
 unzip -q "sonataflow-management-console-webapp-image-build.zip"


### PR DESCRIPTION
Related to - https://issues.redhat.com/browse/SRVLOGIC-643

Failure in OSBS is in this [log](https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/work/tasks/9082/68629082/x86_64.log)

Fails on:
```2025-08-14 13:51:14,595 - atomic_reactor.tasks.binary_container_build - INFO - /tmp/scripts/com.redhat.osl.management.console/configure-osl.sh: line 30: cd: /home/kogito/management-console/app: Not a directory```

Let me know if this is enough.

Note to myself - to sync the changes after to `kubesmarts/osl-images` once merged