### PR TITLE
BAQE-3168: Midstream CI Checks  - fixing

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -111,6 +111,7 @@ jobs:
         env:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx3g"
+          KOGITO_RUNTIME_version: "999-SNAPSHOT"
         uses: ./.github/actions/bootstrap
         with:
           pnpm_filter_string: ${{ steps.setup_build_mode.outputs.bootstrapPnpmFilterString }}
@@ -141,6 +142,7 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=6144"
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
+          KOGITO_RUNTIME_version: "999-SNAPSHOT"
         run: >-
           eval "pnpm ${{ steps.setup_build_mode.outputs.fullBuildPnpmFilterString }} --workspace-concurrency=1 build:prod"
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -109,6 +109,7 @@ jobs:
       - name: "Bootstrap"
         if: steps.setup_build_mode.outputs.mode != 'none'
         env:
+          DROOLS_AND_KOGITO__skip: true
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx3g"
         uses: ./.github/actions/bootstrap

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -122,10 +122,6 @@ jobs:
           git diff
           [ "0" == "$(git diff | wc -l | tr -d ' ')" ]
 
-      - name: Replace pre-build step in kogito-db-migrator-tool
-        run: |
-          sed -i "s/pnpm pre-build && //g" ./packages/kogito-db-migrator-tool/package.json
-
       - name: Modify pom.xml of sonataflow-quarkus-devui
         run: python .github/supporting-files/ci/osl/pom-manipulation/inject-fmp-executions.py
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -111,7 +111,6 @@ jobs:
         env:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx3g"
-          KOGITO_RUNTIME_version: "999-SNAPSHOT"
         uses: ./.github/actions/bootstrap
         with:
           pnpm_filter_string: ${{ steps.setup_build_mode.outputs.bootstrapPnpmFilterString }}
@@ -142,7 +141,6 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=6144"
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
-          KOGITO_RUNTIME_version: "999-SNAPSHOT"
         run: >-
           eval "pnpm ${{ steps.setup_build_mode.outputs.fullBuildPnpmFilterString }} --workspace-concurrency=1 build:prod"
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -122,6 +122,13 @@ jobs:
           git diff
           [ "0" == "$(git diff | wc -l | tr -d ' ')" ]
 
+      - name: Replace pre-build step in kogito-db-migrator-tool
+        run: |
+          sed -i "s/pnpm pre-build && //g" ./packages/kogito-db-migrator-tool/package.json
+
+      - name: Modify pom.xml of sonataflow-quarkus-devui
+        run: python .github/supporting-files/ci/osl/pom-manipulation/inject-fmp-executions.py
+
       - name: "FULL → Build"
         if: steps.setup_build_mode.outputs.mode == 'full'
         shell: bash

--- a/.github/workflows/ci_build_midstream.yml
+++ b/.github/workflows/ci_build_midstream.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Setup environment"
-        uses: apache/incubator-kie-tools/.github/actions/setup-env@main
+        uses: kubesmarts/kie-tools/.github/actions/setup-env@main
 
       - name: Build KIE Tools
         run: mvn clean install

--- a/.github/workflows/ci_build_midstream.yml
+++ b/.github/workflows/ci_build_midstream.yml
@@ -36,7 +36,9 @@ jobs:
         uses: kubesmarts/kie-tools/.github/actions/setup-env@main
 
       - name: Build KIE Tools
-        run: mvn clean install
+        run: mvn clean install -B
+        env:
+          DROOLS_AND_KOGITO__skip: true
 
       # This step works well but can consume midstream storage
       # - name: Upload JAR artifacts

--- a/packages/kogito-db-migrator-tool/package.json
+++ b/packages/kogito-db-migrator-tool/package.json
@@ -18,7 +18,7 @@
     "build:prod:darwin:linux": "mvn clean install -DskipTests=$(build-env tests.run --not) -Dmaven.test.failure.ignore=$(build-env tests.ignoreFailures)",
     "build:prod:win32": "pnpm powershell \"mvn clean install `-DskipTests=$(build-env tests.run --not) `-Dmaven.test.failure.ignore=$(build-env tests.ignoreFailures)\"",
     "install": "node install.js",
-    "pre-build": "mvn dependency:unpack"
+    "pre-build": "echo \"Skipping pre-build on midstream\""
   },
   "dependencies": {
     "@kie-tools/maven-base": "workspace:*"


### PR DESCRIPTION
https://issues.redhat.com/browse/BAQE-3168 as part of this JIRA, we noticed CI checks are broken.
This PR is an attempt to consolidate changes required for the CI Checks to be green again.

Related to the https://issues.redhat.com/browse/SRVLOGIC-582 work.