### PR TITLE
SRVLOGIC-647: Fix Midstream CI Checks downloading upstream artifacts

### DIFF
--- a/.github/supporting-files/ci/osl/export_vars.sh
+++ b/.github/supporting-files/ci/osl/export_vars.sh
@@ -79,8 +79,8 @@ if [[ -f "$ENV_FILE" ]]; then
 fi
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then
-  # GitHub Actions: append into $GITHUB_ENV
-  cat "$MERGED" >> "$GITHUB_ENV"
+  # GitHub Actions: append into $GITHUB_ENV removing empty lines
+  grep -v -E '^\s*$' "$MERGED" >> "$GITHUB_ENV"
 else
   # Local: print to stdout
   cat "$MERGED"

--- a/.github/workflows/ci_build_midstream.yml
+++ b/.github/workflows/ci_build_midstream.yml
@@ -32,10 +32,50 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
 
-      - name: "Setup environment"
-        uses: apache/incubator-kie-tools/.github/actions/setup-env@main
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Run pnpm bootstrap - first time
+        run: pnpm bootstrap -F '@osl/redhat-env...' --no-frozen-lockfile
+        env:
+          DROOLS_AND_KOGITO__skip: true
+          KOGITO_RUNTIME_version: "999-SNAPSHOT"
+        shell: bash
+
+      - name: Setup Environment Variables
+        run: bash ./.github/supporting-files/ci/osl/export_vars.sh
+        shell: bash
+
+      - name: Get Kiegroup git ref urls
+        id: get_kiegroup_git_refs
+        run: |
+          # Get Kiegroup Drools Git Ref
+          DROOLS_GIT_REF=$(git ls-remote "${{ env.DROOLS_AND_KOGITO__droolsRepoUrl}}" refs/heads/main | awk '{print $1}')
+          echo "DROOLS_AND_KOGITO__droolsRepoGitRef=$DROOLS_GIT_REF" >> "$GITHUB_OUTPUT"
+
+          # Get Kiegroup Runtimes Git Ref
+          RUNTIMES_GIT_REF=$(git ls-remote "${{ env.DROOLS_AND_KOGITO__kogitoRuntimesRepoUrl}}" refs/heads/main | awk '{print $1}')
+          echo "DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef=$RUNTIMES_GIT_REF" >> "$GITHUB_OUTPUT"
+
+          # Get Kiegroup Apps Git Ref
+          APPS_GIT_REF=$(git ls-remote "${{ env.DROOLS_AND_KOGITO__kogitoAppsRepoUrl}}" refs/heads/main | awk '{print $1}')
+          echo "DROOLS_AND_KOGITO__kogitoAppsRepoGitRef=$APPS_GIT_REF" >> "$GITHUB_OUTPUT"
+          Get Kiegroup Drools Git Ref
+
+      - name: Prepare maven-base with .mvn/maven.config
+        id: prepare_maven_base_config
+        run: |
+          mkdir ./packages/maven-base/.mvn
+          echo "-Dversion.org.kie.kogito=999-SNAPSHOT" > "./packages/maven-base/.mvn/maven.config"
+          echo "--no-snapshot-updates" >> "./packages/maven-base/.mvn/maven.config"
 
       - name: Build KIE Tools
+        env:
+          DROOLS_AND_KOGITO__skip: true
+          KOGITO_RUNTIME_version: "999-SNAPSHOT"
+          DROOLS_AND_KOGITO__droolsRepoGitRef: "${{ steps.get_kiegroup_git_refs.outputs.DROOLS_AND_KOGITO__droolsRepoGitRef}}"
+          DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: "${{ steps.get_kiegroup_git_refs.outputs.DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef}}"
+          DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: "${{ steps.get_kiegroup_git_refs.outputs.DROOLS_AND_KOGITO__kogitoAppsRepoGitRef}}"
         run: mvn clean install
 
       # This step works well but can consume midstream storage

--- a/.github/workflows/ci_build_midstream.yml
+++ b/.github/workflows/ci_build_midstream.yml
@@ -20,6 +20,7 @@
 name: Build Midstream KIE Tools
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: ["**"]
     types: [opened, reopened, ready_for_review, synchronize]

--- a/.github/workflows/ci_build_midstream.yml
+++ b/.github/workflows/ci_build_midstream.yml
@@ -61,7 +61,6 @@ jobs:
           # Get Kiegroup Apps Git Ref
           APPS_GIT_REF=$(git ls-remote "${{ env.DROOLS_AND_KOGITO__kogitoAppsRepoUrl}}" refs/heads/main | awk '{print $1}')
           echo "DROOLS_AND_KOGITO__kogitoAppsRepoGitRef=$APPS_GIT_REF" >> "$GITHUB_OUTPUT"
-          Get Kiegroup Drools Git Ref
 
       - name: Prepare maven-base with .mvn/maven.config
         id: prepare_maven_base_config
@@ -69,6 +68,32 @@ jobs:
           mkdir ./packages/maven-base/.mvn
           echo "-Dversion.org.kie.kogito=999-SNAPSHOT" > "./packages/maven-base/.mvn/maven.config"
           echo "--no-snapshot-updates" >> "./packages/maven-base/.mvn/maven.config"
+
+      - name: "Clone and Build Drools, Runtimes and Apps Repositories"
+        run: |
+          echo "KOGITO_RUNTIME_version is $KOGITO_RUNTIME_version: Cloning and building extra repositories."
+          cd ..
+
+          echo "Cloning drools main branch)..."
+          git clone --depth 1 --branch main https://github.com/kiegroup/drools.git
+          cd drools
+          mvn clean install -Dquickly
+          cd ..
+          rm -rf drools
+
+          echo "Cloning kogito-runtimes (main branch)..."
+          git clone --depth 1 --branch main https://github.com/kiegroup/kogito-runtimes.git
+          cd kogito-runtimes
+          mvn clean install -Dquickly
+          cd ..
+          rm -rf kogito-runtimes
+
+          echo "Cloning kogito-apps (main branch)..."
+          git clone --depth 1 --branch main https://github.com/kiegroup/kogito-apps.git
+          cd kogito-apps
+          mvn clean install -Dquickly
+          cd ..
+          rm -rf kogito-apps
 
       - name: Build KIE Tools
         env:

--- a/.github/workflows/ci_build_midstream.yml
+++ b/.github/workflows/ci_build_midstream.yml
@@ -36,6 +36,32 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-env
 
+      - name: "Clone and Build Drools, Runtimes and Apps Repositories"
+        run: |
+          echo "KOGITO_RUNTIME_version is $KOGITO_RUNTIME_version: Cloning and building extra repositories."
+          cd ..
+
+          echo "Cloning drools main branch)..."
+          git clone --depth 1 --branch main https://github.com/kiegroup/drools.git
+          cd drools
+          mvn clean install -Dquickly
+          cd ..
+          rm -rf drools
+
+          echo "Cloning kogito-runtimes (main branch)..."
+          git clone --depth 1 --branch main https://github.com/kiegroup/kogito-runtimes.git
+          cd kogito-runtimes
+          mvn clean install -Dquickly
+          cd ..
+          rm -rf kogito-runtimes
+
+          echo "Cloning kogito-apps (main branch)..."
+          git clone --depth 1 --branch main https://github.com/kiegroup/kogito-apps.git
+          cd kogito-apps
+          mvn clean install -Dquickly
+          cd ..
+          rm -rf kogito-apps
+
       - name: Run pnpm bootstrap - first time
         run: pnpm bootstrap -F '@osl/redhat-env...' --no-frozen-lockfile
         env:
@@ -68,32 +94,6 @@ jobs:
           mkdir ./packages/maven-base/.mvn
           echo "-Dversion.org.kie.kogito=999-SNAPSHOT" > "./packages/maven-base/.mvn/maven.config"
           echo "--no-snapshot-updates" >> "./packages/maven-base/.mvn/maven.config"
-
-      - name: "Clone and Build Drools, Runtimes and Apps Repositories"
-        run: |
-          echo "KOGITO_RUNTIME_version is $KOGITO_RUNTIME_version: Cloning and building extra repositories."
-          cd ..
-
-          echo "Cloning drools main branch)..."
-          git clone --depth 1 --branch main https://github.com/kiegroup/drools.git
-          cd drools
-          mvn clean install -Dquickly
-          cd ..
-          rm -rf drools
-
-          echo "Cloning kogito-runtimes (main branch)..."
-          git clone --depth 1 --branch main https://github.com/kiegroup/kogito-runtimes.git
-          cd kogito-runtimes
-          mvn clean install -Dquickly
-          cd ..
-          rm -rf kogito-runtimes
-
-          echo "Cloning kogito-apps (main branch)..."
-          git clone --depth 1 --branch main https://github.com/kiegroup/kogito-apps.git
-          cd kogito-apps
-          mvn clean install -Dquickly
-          cd ..
-          rm -rf kogito-apps
 
       - name: Build KIE Tools
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,16 @@
               <goal>pnpm</goal>
             </goals>
             <configuration>
+              <environmentVariables>
+                <DROOLS_AND_KOGITO__skip>true</DROOLS_AND_KOGITO__skip>
+                <KOGITO_RUNTIME_version>999-SNAPSHOT</KOGITO_RUNTIME_version>
+                <DROOLS_AND_KOGITO__droolsRepoGitRef
+                >${env.DROOLS_AND_KOGITO__droolsRepoGitRef}</DROOLS_AND_KOGITO__droolsRepoGitRef>
+                <DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef
+                >${env.DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef}</DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef>
+                <DROOLS_AND_KOGITO__kogitoAppsRepoGitRef
+                >${env.DROOLS_AND_KOGITO__kogitoAppsRepoGitRef}</DROOLS_AND_KOGITO__kogitoAppsRepoGitRef>
+              </environmentVariables>
               <skip>${skip.ui.deps}</skip>
               <arguments
               >bootstrap -F @kie-tools/sonataflow-quarkus-devui... -F @kie-tools/sonataflow-management-console-webapp... -F @kie-tools/kogito-db-migrator-tool... -F @kie-tools/kogito-data-index-webapp...</arguments>


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/SRVLOGIC-647

**Description:**
The `Midstream CI Checks` is broken with this error:

```
[INFO] packages/maven-base install: [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/kie/kogito/kogito-kie-bom/999-20250622-local/kogito-kie-bom-999-20250622-local.pom
[INFO] packages/maven-base install: [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/kie/kogito/kogito-apps-bom/999-20250622-local/kogito-apps-bom-999-20250622-local.pom
[INFO] packages/maven-base install: [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/drools/drools-bom/999-20250622-local/drools-bom-999-20250622-local.pom
Error: s/maven-base install: [ERROR] [ERROR] Some problems were encountered while processing the POMs:
Error: packages/maven-base install: [ERROR] Non-resolvable import POM: The following artifacts could not be resolved: org.kie.kogito:kogito-bom:pom:999-20250622-local (absent): Could not find artifact org.kie.kogito:kogito-bom:pom:999-20250622-local in central (https://repo.maven.apache.org/maven2) @ org.kie:kie-tools-maven-base:${revision}, /home/runner/work/kie-tools/kie-tools/packages/maven-base/pom.xml, line 149, column 19
```

Action link: https://github.com/kubesmarts/kie-tools/actions/runs/17233509160
Thread: https://redhat-internal.slack.com/archives/C06QGGAB01Z/p1756195046203049

**Preview:**
https://github.com/kubesmarts/kie-tools/actions/runs/17271349783