### PR TITLE
SRVLOGIC-643: Update path to management console artifact

### DIFF
--- a/packages/osl-management-console-image/resources/modules/osl-management-console/configure-osl.sh
+++ b/packages/osl-management-console-image/resources/modules/osl-management-console/configure-osl.sh
@@ -22,11 +22,13 @@ set -e
 SCRIPT_DIR=$(dirname "${0}")
 MGMT_CONSOLE_HOME="${KOGITO_HOME}/management-console"
 
+mkdir -p ${MGMT_CONSOLE_HOME}/app
+
 # Add the dist files that can't be downloaded on Cpaas
 cp -v "${SCRIPT_DIR}/added/EnvJson.schema.json" "${MGMT_CONSOLE_HOME}"
 cp -v "${SCRIPT_DIR}/added/image-env-to-json-linux-amd64" "${MGMT_CONSOLE_HOME}"
 
 # Unzip the app
 cd "${MGMT_CONSOLE_HOME}/app"
-unzip -q "sonataflow-management-console-webapp-image-build.zip"
-rm -rf "sonataflow-management-console-webapp-image-build.zip"
+unzip -q "/tmp/artifacts/sonataflow-management-console-webapp-image-build.zip"
+rm -rf "/tmp/artifacts/sonataflow-management-console-webapp-image-build.zip"


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVLOGIC-643 

This fixes the build and adds the management console to nightly product build.
already tested and synced these changes to osl-images in https://github.com/kubesmarts/osl-images/pull/38 