### PR TITLE
SRVLOGIC-661: Remove the bootstrap and build from sync workflow

### DIFF
--- a/.github/workflows/osl_sync_main.yml
+++ b/.github/workflows/osl_sync_main.yml
@@ -51,29 +51,6 @@ jobs:
       - name: Reset lock & graph to upstream
         run: git checkout upstream/main -- pnpm-lock.yaml repo/graph.*
 
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
-
-      - name: Replace pre-build step in kogito-db-migrator-tool
-        run: |
-          sed -i "s/pnpm pre-build && //g" ./packages/kogito-db-migrator-tool/package.json
-
-      - name: Modify pom.xml of sonataflow-quarkus-devui
-        run: python .github/supporting-files/ci/osl/pom-manipulation/inject-fmp-executions.py
-
-      - name: Bootstrap & Build
-        shell: bash
-        env:
-          KIE_TOOLS_BUILD__runTests: "false"
-          KIE_TOOLS_BUILD__runEndToEndTests: "false"
-          KIE_TOOLS_BUILD__buildContainerImages: "true"
-          KIE_TOOLS_BUILD__ignoreTestFailures: "true"
-          KIE_TOOLS_BUILD__ignoreEndToEndTestFailures: "true"
-          NODE_OPTIONS: "--max_old_space_size=4096"
-        run: |
-          pnpm bootstrap --no-frozen-lockfile
-          pnpm -r ${{ env.PNPM_FILTER }} --workspace-concurrency=1 build:prod
-
       - name: Capture Changes
         id: capture_changes
         run: |


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVLOGIC-661 

As confirmed here - https://github.com/kubesmarts/kie-tools/actions/runs/17609207259/job/50026976345
We need to execute build of Drools, Runtimes and Apps with `999-SNAPSHOT` prior to the `Bootstrap and build` so this works well.
We decided to work around by removing these build check for now and leave them to other workflows.
We should however aim to restore this checks on sync workflow as it allows us to check if the merge is not breaking the workflows we need to function.