### PR TITLE
[SRVLOGIC-601] - Migrate OSL Operator to stable channel

### DIFF
--- a/packages/osl-operator-bundle-image/resources/bundle/metadata/annotations.yaml
+++ b/packages/osl-operator-bundle-image/resources/bundle/metadata/annotations.yaml
@@ -1,3 +1,5 @@
 # Annotations added to this file will be merged with the final dist bundle
 annotations:
   com.redhat.openshift.versions: v4.13
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/packages/osl-operator-bundle-image/resources/config/manifests/bases/logic-operator-rhel9.clusterserviceversion.yaml
+++ b/packages/osl-operator-bundle-image/resources/config/manifests/bases/logic-operator-rhel9.clusterserviceversion.yaml
@@ -286,7 +286,7 @@ spec:
   maintainers:
     - email: serverless-logic-team@redhat.com
       name: Red Hat
-  maturity: alpha
+  maturity: stable
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat

--- a/packages/osl-operator-bundle-image/resources/scripts/add_annotations.py
+++ b/packages/osl-operator-bundle-image/resources/scripts/add_annotations.py
@@ -41,7 +41,7 @@ def merge_annotations():
         # Add the source annotations to the end of destination annotations
         dest_annotations[key] = value
 
-    last_key = list(dest_annotations.keys())[-1]
+    last_key = list(dest_annotations.keys())[-2]
     dest_annotations.yaml_set_comment_before_after_key(last_key, before="Additional Red Hat annotations", indent=2)
 
     # Write back the modified data to the destination file, preserving formatting


### PR DESCRIPTION
I missed this one since the bundle prod package is regenerating the bundle based on RHT info and not copying from the `sonataflow-operator` package.

See https://issues.redhat.com/browse/SRVLOGIC-601