### PR TITLE
[9.104.x-prod] [SRVLOGIC-679] - Fix prod ci with missing properly kogito-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
             <configuration>
               <environmentVariables>
                 <DROOLS_AND_KOGITO__skip>true</DROOLS_AND_KOGITO__skip>
-                <KOGITO_RUNTIME_version>9.104.0</KOGITO_RUNTIME_version>
+                <KOGITO_RUNTIME_version>${version.org.kie.kogito}</KOGITO_RUNTIME_version>
                 <DROOLS_AND_KOGITO__droolsRepoGitRef
                 >${env.DROOLS_AND_KOGITO__droolsRepoGitRef}</DROOLS_AND_KOGITO__droolsRepoGitRef>
                 <DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef


### PR DESCRIPTION
hardcoded versions or different properties causes PME doesn't set all of them to build nightly one which is generated as 9.104.0-######