### PR TITLE
[SRVLOGIC-736] Remove unneeded pnpm filters in CI

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -192,7 +192,7 @@ jobs:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
         run: >-
-          eval "pnpm ${{ steps.setup_build_mode.outputs.fullBuildPnpmFilterString }} -F '!@kie-tools/dmn-marshaller-backend-compatibility-tester' --workspace-concurrency=1 build:prod"
+          eval "pnpm ${{ steps.setup_build_mode.outputs.fullBuildPnpmFilterString }} --workspace-concurrency=1 build:prod"
 
       - name: "PARTIAL → Build upstream"
         if: steps.setup_build_mode.outputs.mode == 'partial' && steps.setup_build_mode.outputs.upstreamPnpmFilterString != ''
@@ -204,7 +204,7 @@ jobs:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
         run: |
-          eval "pnpm ${{ steps.setup_build_mode.outputs.upstreamPnpmFilterString }} -F '!@kie-tools/dmn-marshaller-backend-compatibility-tester' build:dev"
+          eval "pnpm ${{ steps.setup_build_mode.outputs.upstreamPnpmFilterString }} build:dev"
 
       - name: "PARTIAL → Build changed and downstream"
         shell: bash
@@ -229,7 +229,7 @@ jobs:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
         run: |
-          eval "pnpm ${{ steps.setup_build_mode.outputs.affectedPnpmFilterString }} -F '!@kie-tools/dmn-marshaller' -F '!@kie-tools/dmn-marshaller-backend-compatibility-tester' --workspace-concurrency=1 build:prod"
+          eval "pnpm ${{ steps.setup_build_mode.outputs.affectedPnpmFilterString }} --workspace-concurrency=1 build:prod"
 
       - name: "Check tests result (`main` only)"
         if: always() && !cancelled() && steps.setup_build_mode.outputs.mode != 'none'

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -109,7 +109,7 @@ jobs:
           fi
           echo "SERVERLESS_LOGIC_WEB_TOOLS__buildInfo=$SERVERLESS_LOGIC_WEB_TOOLS__buildInfo"
           cd kie-tools
-          pnpm -F @kie-tools/serverless-logic-web-tools... -F '!@kie-tools/dmn-marshaller-backend-compatibility-tester' build:prod
+          pnpm -F @kie-tools/serverless-logic-web-tools... build:prod
 
       - name: "Checkout serverless-logic-sandbox-deployment"
         uses: actions/checkout@v3

--- a/packages/sonataflow-management-console-webapp/pom.xml
+++ b/packages/sonataflow-management-console-webapp/pom.xml
@@ -61,8 +61,7 @@
             <configuration>
               <skip>${skip.ui.build}</skip>
               <pnpmInheritsProxyConfigFromMaven>false</pnpmInheritsProxyConfigFromMaven>
-              <arguments
-              >-F sonataflow-management-console-webapp... -F !@kie-tools/dmn-marshaller-backend-compatibility-tester -F !@kie-tools/dmn-testing-models build:prod</arguments>
+              <arguments>-F sonataflow-management-console-webapp... build:prod</arguments>
               <environmentVariables>
                 <KIE_TOOLS_BUILD__runTests>false</KIE_TOOLS_BUILD__runTests>
                 <KIE_TOOLS_BUILD__runIntegrationTests>false</KIE_TOOLS_BUILD__runIntegrationTests>

--- a/packages/sonataflow-quarkus-devui/pom.xml
+++ b/packages/sonataflow-quarkus-devui/pom.xml
@@ -95,8 +95,7 @@
             <configuration>
               <skip>${skip.ui.build}</skip>
               <pnpmInheritsProxyConfigFromMaven>false</pnpmInheritsProxyConfigFromMaven>
-              <arguments
-              >-F serverless-workflow-dev-ui-webapp... -F !@kie-tools/dmn-marshaller-backend-compatibility-tester -F !@kie-tools/dmn-testing-models build:prod</arguments>
+              <arguments>-F serverless-workflow-dev-ui-webapp... build:prod</arguments>
               <environmentVariables>
                 <KIE_TOOLS_BUILD__runTests>false</KIE_TOOLS_BUILD__runTests>
                 <KIE_TOOLS_BUILD__runIntegrationTests>false</KIE_TOOLS_BUILD__runIntegrationTests>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVLOGIC-736

Needs to be rebased after https://github.com/kubesmarts/kie-tools/pull/245 is merged. 

- Removes unneeded pnpm filters that are not needed anymore because of the latest changes in kie-tools. 