### PR TITLE
SRVLOGIC-748 - Add automated weekly workflow for publishing container images to Quay.io.

### DIFF
--- a/.github/workflows/osl_publish_images_snapshots.yml
+++ b/.github/workflows/osl_publish_images_snapshots.yml
@@ -1,7 +1,6 @@
 name: "CI :: OSL :: Publish Images Snapshots"
-
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       dry_run:
         type: boolean

--- a/.github/workflows/osl_publish_images_snapshots_manually.yml
+++ b/.github/workflows/osl_publish_images_snapshots_manually.yml
@@ -1,0 +1,34 @@
+name: "CI :: OSL :: Publish Images Snapshots Manually"
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        required: true
+      USE_REMOTE_ARTIFACTS:
+        description: "True to use productized artifacts from Red Hat Maven repository"
+        type: boolean
+        required: false
+        default: false
+      KOGITO_VERSION:
+        description: "Specify the version for Kogito Runtime"
+        required: false
+        default: "999-SNAPSHOT"
+      IMAGE_TAG:
+        description: "Specify the tag for the images"
+        required: false
+        default: "main"
+
+permissions:
+  contents: read
+
+jobs:
+  call-images-publishing-workflow:
+    uses: ./.github/workflows/osl_publish_images_snapshots.yml
+    with:
+      dry_run: ${{ inputs.dry_run }}
+      USE_REMOTE_ARTIFACTS: ${{ inputs.USE_REMOTE_ARTIFACTS }}
+      KOGITO_VERSION: ${{ inputs.KOGITO_VERSION }}
+      IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+    secrets: inherit

--- a/.github/workflows/osl_publish_images_snapshots_weekly.yml
+++ b/.github/workflows/osl_publish_images_snapshots_weekly.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/osl_publish_images_snapshots.yml
     with:
       dry_run: false
-      USE_REMOTE_ARTIFACTS: true
-      KOGITO_VERSION: "9.104.0.redhat-00005"
-      IMAGE_TAG: "9.104.x-prod"
+      USE_REMOTE_ARTIFACTS: false
+      KOGITO_VERSION: "999-SNAPSHOT"
+      IMAGE_TAG: "main"
     secrets: inherit

--- a/.github/workflows/osl_publish_images_snapshots_weekly.yml
+++ b/.github/workflows/osl_publish_images_snapshots_weekly.yml
@@ -1,0 +1,17 @@
+name: "CI :: OSL :: Publish Images Snapshots Weekly"
+on:
+  schedule:
+    - cron: '0 10 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  call-images-publishing-workflow:
+    uses: ./.github/workflows/osl_publish_images_snapshots.yml
+    with:
+      dry_run: false
+      USE_REMOTE_ARTIFACTS: true
+      KOGITO_VERSION: "9.104.0.redhat-00005"
+      IMAGE_TAG: "9.104.x-prod"
+    secrets: inherit

--- a/.github/workflows/osl_publish_images_snapshots_weekly.yml
+++ b/.github/workflows/osl_publish_images_snapshots_weekly.yml
@@ -1,7 +1,7 @@
 name: "CI :: OSL :: Publish Images Snapshots Weekly"
 on:
   schedule:
-    - cron: '0 10 * * 5'
+    - cron: "0 10 * * 5"
 
 permissions:
   contents: read


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/SRVLOGIC-748

- Makes the original workflow a reusable workflow. 
- Adds a manual version, that calls the new reusable workflow. 
- Adds an automated versions, that calls the new reusable workflow and triggers each Friday at 10:00, so it can be checked on Friday, if something goes wrong. 

Not sure how to test this properly, as I am not able to test the workflows locally on my laptop. Any ideas, please? 

Please also check if I set the parameters in the automated run correctly. 