### PR TITLE
cd into working directory when building parent poms.

### DIFF
--- a/.github/actions/setup-kie-tools/action.yml
+++ b/.github/actions/setup-kie-tools/action.yml
@@ -56,6 +56,7 @@ runs:
       if: inputs.USE_REMOTE_ARTIFACTS == 'true'
       shell: bash
       run: |
+        cd ${{ inputs.WORKING_DIR }}
         cp -f .github/supporting-files/ci/midstream-mvn-config/settings.xml settings.xml
         cp -f .github/supporting-files/ci/midstream-mvn-config/settings.xml packages/maven-base/settings.xml
         cp -f .github/supporting-files/ci/midstream-mvn-config/maven-m2-repo-via-http-image/settings.xml.envsubst packages/maven-m2-repo-via-http-image/settings.xml.envsubst

--- a/.github/actions/setup-kie-tools/action.yml
+++ b/.github/actions/setup-kie-tools/action.yml
@@ -69,6 +69,7 @@ runs:
         else
           SETTINGS_ARG=""
         fi
+        cd ${{ inputs.WORKING_DIR }}
         mvn -f pom.xml $SETTINGS_ARG -Dversion.org.kie.kogito=${{ inputs.KOGITO_VERSION }} install -N
         mvn -f packages/pom.xml $SETTINGS_ARG -Dversion.org.kie.kogito=${{ inputs.KOGITO_VERSION }} install -N
 


### PR DESCRIPTION
There is a missing cd into workspace directory when installing the pom.xmls in GH actions. 