### PR TITLE
Add required attributes to workflow parameters.

### DIFF
--- a/.github/workflows/osl_publish_images_snapshots.yml
+++ b/.github/workflows/osl_publish_images_snapshots.yml
@@ -12,10 +12,12 @@ on:
         default: false
       KOGITO_VERSION:
         description: "Specify the version for Kogito Runtime"
+        type: string
         required: false
         default: "999-SNAPSHOT"
       IMAGE_TAG:
         description: "Specify the tag for the images"
+        type: string
         required: false
         default: "main"
 

--- a/.github/workflows/osl_publish_images_snapshots_manually.yml
+++ b/.github/workflows/osl_publish_images_snapshots_manually.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
+        description: "Set to true for test runs that does not push the images. "
         type: boolean
         required: true
       USE_REMOTE_ARTIFACTS:


### PR DESCRIPTION
- Adds now required attributes to Quay.io publishing workflow. 

For some reason the old configuration of parameters we used in the past doesn't work when I used it in a "reusable workflow". 