### PR TITLE
Use branch 9.104.x for GH action setup-maven-cache.

### DIFF
--- a/.github/actions/setup-kie-tools/action.yml
+++ b/.github/actions/setup-kie-tools/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Setup local maven cache
       if: inputs.USE_REMOTE_ARTIFACTS == 'false'
       id: setup_maven_cache
-      uses: kubesmarts/kie-tools/.github/actions/setup-maven-cache@main
+      uses: kubesmarts/kie-tools/.github/actions/setup-maven-cache@9.104.x-prod
       with:
         DEPS_BRANCHNAME: ${{ inputs.DEPS_BRANCHNAME }}
         WORKING_DIR: ${{ inputs.WORKING_DIR }}


### PR DESCRIPTION
- It was using main, which is incorrect as the prod branches have updated pom.xmls etc., so e.g. running remove_modules.sh fails. 

This fix is needed to update start.kubesmarts.org. 