### PR TITLE
Manual sync of remaining changes before sonataflow removal in Apache KIE

### DIFF
--- a/packages/maven-base/not-reproducible-plugins.properties
+++ b/packages/maven-base/not-reproducible-plugins.properties
@@ -84,7 +84,7 @@ org.eclipse.jetty+jetty-jspc-maven-plugin=fail:https://github.com/eclipse/jetty.
 
 org.jboss.jandex+jandex-maven-plugin=fail:https://github.com/wildfly/jandex-maven-plugin/pull/35
 
-org.springframework.boot+spring-boot-maven-plugin=3.5.10
+org.springframework.boot+spring-boot-maven-plugin=3.5.12
 # https://github.com/spring-projects/spring-boot/issues/21005
 
 org.vafer+jdeb=1.10


### PR DESCRIPTION
(cherry picked from commit 651ae03127564cf505575fed4d8362cf8aa4e1de)

This is the only commit missing from Apache KIE, before sonataflow was removed there. 