### PR TITLE
NO_ISSUE: Update CI build matrix to exclude Windows

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-14]
         partition: [0, 1]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Removed Windows from CI build matrix.

it is broken so let's not run it, until fixed.