### PR TITLE
Remove obsolete commands from MacOS PR checks.

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -241,7 +241,6 @@ runs:
         echo "STEP: Update bash for macOS (macOS Only)"
         brew update
         brew install bash
-        brew uninstall node@20
         echo "/usr/local/bin" >> $GITHUB_PATH
 
     - name: "Print storage usage (after setup)"


### PR DESCRIPTION
Node 20 is deprecated in GitHub for some time, Looks like it was removed also from Homebrew as the removed command started to fail in the PR checks. 