### PR TITLE
[NO-ISSUE] Update MacOS in PR checks to macos-latest.

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         partition: [0, 1]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macos-14 is not the recent version of MacOS anymore. This updates the MacOS runners to use the latest stable considered by GitHub MacOS version, currently being MacOS 15. 