### PR TITLE
SRVLOGIC-1022: Add extra input for kubesmarts custom publish job

### DIFF
--- a/.github/workflows/kubesmarts_custom_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_custom_build_and_publish.yml
@@ -20,6 +20,16 @@ on:
         type: string
         required: true
         default: 0.0.0
+      KOGITO_VERSION:
+        type: string
+        description: "Specify the version for Kogito Runtime"
+        required: false
+        default: "111-SNAPSHOT"
+      USE_REMOTE_ARTIFACTS:
+        type: string
+        description: "Use productized artifacts from Red Hat Maven repository"
+        required: false
+        default: "false"
 
 concurrency:
   group: kubesmarts-custom-build-publish-${{ github.event.inputs.environment }}


### PR DESCRIPTION
Related to https://redhat.atlassian.net/browse/SRVLOGIC-1022

Forward ports the changes already done on `X.Y.Z-prod` branches