### PR TITLE
[Security] Fix Dependabot alert #62: Update org.assertj:assertj-core to 3.27.7

### DIFF
--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -65,7 +65,7 @@
 
     <!-- Resolved artifacts -->
     <version.org.junit>4.13.2</version.org.junit>
-    <version.org.assertj>3.14.0</version.org.assertj>
+    <version.org.assertj>3.27.7</version.org.assertj>
     <version.org.mockito>3.6.0</version.org.mockito>
     <version.org.jboss.resteasy>3.15.1.Final</version.org.jboss.resteasy>
     <version.org.jboss.errai>4.15.0.Final</version.org.jboss.errai>


### PR DESCRIPTION
## 🔒 Security Fix: Update org.assertj:assertj-core to 3.27.7

### Summary
Fixes Dependabot security alert #62 by updating AssertJ from 3.14.0 to 3.27.7.

### Security Issue
- **CVE**: CVE-2026-24400
- **GHSA**: GHSA-rqfh-9r24-8c9r
- **Severity**: High
- **Summary**: AssertJ has XML External Entity (XXE) vulnerability when parsing untrusted XML via isXmlEqualTo assertion

### Changes
- Updated `version.org.assertj` from `3.14.0` to `3.27.7` in `packages/dashbuilder/pom.xml`

### Verification
- ✅ Maven compilation successful
- ✅ Backward compatible version update

---
🤖 **Automated fix by [Dependabot Auto-Fix Skill](https://github.com/baldimir/ai-tools/tree/main/skills/dependabot-autofix)**