### PR TITLE
[Security] Fix Dependabot alert #59: Update commons-io to 2.14.0

### DIFF
--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -69,7 +69,7 @@
     <version.org.mockito>3.6.0</version.org.mockito>
     <version.org.jboss.resteasy>3.15.1.Final</version.org.jboss.resteasy>
     <version.org.jboss.errai>4.15.0.Final</version.org.jboss.errai>
-    <version.commons-io>2.7</version.commons-io>
+    <version.commons-io>2.14.0</version.commons-io>
     <version.commons-codec>1.16.0</version.commons-codec>
     <version.com.google.gwt>2.9.0</version.com.google.gwt>
     <version.org.gwtbootstrap3>1.0.1</version.org.gwtbootstrap3>


### PR DESCRIPTION
## 🔒 Security Fix: Update commons-io to 2.14.0

### Summary
Fixes Dependabot security alert #59 by updating Apache Commons IO from 2.7 to 2.14.0.

### Security Issue
- **CVE**: CVE-2024-47554
- **GHSA**: GHSA-78wr-2p64-hpwj
- **Severity**: High
- **Summary**: Apache Commons IO: Possible denial of service attack on untrusted input to XmlStreamReader

### Changes
- Updated `version.commons-io` from `2.7` to `2.14.0` in `packages/dashbuilder/pom.xml`

### Verification
- ✅ Maven compilation successful
- ✅ Backward compatible version update

---
🤖 **Automated fix by [Dependabot Auto-Fix Skill](https://github.com/baldimir/ai-tools/tree/main/skills/dependabot-autofix)**