### PR TITLE
[Security] Fix Dependabot alert #60: Update org.jboss.resteasy:resteasy-multipart-provider to 3.15.6.Final

### DIFF
--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -67,7 +67,7 @@
     <version.org.junit>4.13.2</version.org.junit>
     <version.org.assertj>3.14.0</version.org.assertj>
     <version.org.mockito>3.6.0</version.org.mockito>
-    <version.org.jboss.resteasy>3.15.1.Final</version.org.jboss.resteasy>
+    <version.org.jboss.resteasy>3.15.6.Final</version.org.jboss.resteasy>
     <version.org.jboss.errai>4.15.0.Final</version.org.jboss.errai>
     <version.commons-io>2.7</version.commons-io>
     <version.commons-codec>1.16.0</version.commons-codec>


### PR DESCRIPTION
## 🔒 Security Fix: Update org.jboss.resteasy:resteasy-multipart-provider to 3.15.6.Final

### Summary
Fixes Dependabot security alert #60 by updating RESTEasy multipart provider from 3.15.1.Final to 3.15.6.Final.

### Security Issue
- **CVE**: CVE-2023-0482
- **Severity**: Medium
- **Summary**: Insecure Temporary File in RESTEasy

### Changes
- Updated `version.org.jboss.resteasy` from `3.15.1.Final` to `3.15.6.Final` in `packages/dashbuilder/pom.xml`

### Verification
- ✅ Maven compilation successful
- ✅ Backward compatible version update

---
🤖 **Automated fix by [Dependabot Auto-Fix Skill](https://github.com/baldimir/ai-tools/tree/main/skills/dependabot-autofix)**