### PR TITLE
[Security] Fix Dependabot alert #61: Update org.apache.poi:poi-ooxml to 5.4.0

### DIFF
--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -77,7 +77,7 @@
     <version.net.sf.opencsv>2.3</version.net.sf.opencsv>
     <version.org.apache.tomcat>6.0.32</version.org.apache.tomcat>
     <version.jakarta.enterprise.cdi-api>2.0.2</version.jakarta.enterprise.cdi-api>
-    <version.org.apache.poi>4.1.2</version.org.apache.poi>
+    <version.org.apache.poi>5.4.0</version.org.apache.poi>
     <version.org.owasp.encoder>1.2</version.org.owasp.encoder>
     <version.org.jboss.xnio>3.8.14.Final</version.org.jboss.xnio>
     <version.io.netty>4.1.59.Final</version.io.netty>


### PR DESCRIPTION
## 🔒 Security Fix: Update org.apache.poi:poi-ooxml to 5.4.0

### Summary
Fixes Dependabot security alert #61 by updating Apache POI from 4.1.2 to 5.4.0.

### Security Issue
- **Severity**: High
- **Summary**: Multiple CVEs in Apache POI

### Changes
- Updated `version.org.apache.poi` from `4.1.2` to `5.4.0` in `packages/dashbuilder/pom.xml`

### Verification
- ✅ Maven compilation successful
- ✅ All tests passing (59 tests, 0 failures)
- ✅ Backward compatible version update

---
🤖 **Automated fix by [Dependabot Auto-Fix Skill](https://github.com/baldimir/ai-tools/tree/main/skills/dependabot-autofix)**