### PR TITLE
SRVLOGIC-1022: Fix kubesmarts release workflows

### DIFF
--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -26,6 +26,11 @@ on:
         description: "Specify the version for Kogito Runtime"
         required: false
         default: "111-SNAPSHOT"
+      USE_REMOTE_ARTIFACTS:
+        type: string
+        description: "Use productized artifacts from Red Hat Maven repository"
+        required: false
+        default: "false"
     secrets:
       KIE1_TOKEN:
         required: true
@@ -92,6 +97,7 @@ jobs:
           DEPS_BRANCHNAME: ${{ inputs.tag }}
           PNPM_FILTER: "-F @kie-tools/serverless-logic-web-tools..."
           WORKING_DIR: kie-tools
+          USE_REMOTE_ARTIFACTS: ${{ inputs.USE_REMOTE_ARTIFACTS }}
 
       - name: "Parse `commit_sha`"
         id: commit_sha

--- a/.github/workflows/kubesmarts_custom_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_custom_build_and_publish.yml
@@ -46,6 +46,8 @@ jobs:
       environment: ${{ github.event.inputs.environment }}
       tag: ${{ github.event.inputs.tag }}
       version: ${{ github.event.inputs.version }}
+      KOGITO_VERSION: ${{ github.event.inputs.KOGITO_VERSION }}
+      USE_REMOTE_ARTIFACTS: ${{ github.event.inputs.USE_REMOTE_ARTIFACTS }}
     secrets:
       KIE1_TOKEN: ${{ secrets.KIE1_TOKEN }}
       KIE1_EMAIL: ${{ secrets.KIE1_EMAIL }}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/SRVLOGIC-1022

- Fix missing input in kubesmarts_build_and_publish
- Fix missing input for setup-kie-tools

This is a cherry-pick of changes from product branches, adjusted for `main`