### PR TITLE
[Security] Update mysql JDBC driver version.

### DIFF
--- a/packages/dashbuilder/appformer/pom.xml
+++ b/packages/dashbuilder/appformer/pom.xml
@@ -106,7 +106,7 @@
 
     <!-- database testing -->
     <version.org.mariadb.jdbc>1.3.6</version.org.mariadb.jdbc>
-    <version.org.mysql-driver>8.0.28</version.org.mysql-driver>
+    <version.org.mysql-driver>9.7.0</version.org.mysql-driver>
     <version.org.postgres-driver>42.7.11</version.org.postgres-driver>
 
     <version.org.arquillian.cube>1.15.3</version.org.arquillian.cube>
@@ -971,8 +971,8 @@
 
       <!-- Test deps -->
       <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
         <version>${version.org.mysql-driver}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Switches to the current jdbc driver. Mysql changed groupIds in the past. This new one should be a drop in replacement. 