### PR TITLE
NO-ISSUE: Update webpack-cli

### DIFF
--- a/examples/micro-frontends-multiplying-architecture-base64png-editor-chrome-extension/package.json
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor-chrome-extension/package.json
@@ -32,7 +32,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0",
     "zip-webpack-plugin": "^4.0.1"

--- a/examples/micro-frontends-multiplying-architecture-base64png-editor-on-webapp/package.json
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor-on-webapp/package.json
@@ -28,7 +28,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/examples/micro-frontends-multiplying-architecture-base64png-editor-vscode-extension/package.json
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor-vscode-extension/package.json
@@ -35,7 +35,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/package.json
+++ b/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/package.json
@@ -31,7 +31,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view-on-webapp/package.json
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view-on-webapp/package.json
@@ -28,7 +28,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view-vscode-extension/package.json
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view-vscode-extension/package.json
@@ -34,7 +34,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/examples/serverless-workflow-editor-standalone-on-webapp/package.json
+++ b/examples/serverless-workflow-editor-standalone-on-webapp/package.json
@@ -29,7 +29,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/examples/uniforms-patternfly/package.json
+++ b/examples/uniforms-patternfly/package.json
@@ -36,7 +36,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/chrome-extension-serverless-workflow-editor/package.json
+++ b/packages/chrome-extension-serverless-workflow-editor/package.json
@@ -61,7 +61,7 @@
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.16.0",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0",
     "zip-webpack-plugin": "^4.0.1"

--- a/packages/cors-proxy/package.json
+++ b/packages/cors-proxy/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^29.1.5",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-merge": "^5.9.0"
   }
 }

--- a/packages/form-code-generator-patternfly-theme/package.json
+++ b/packages/form-code-generator-patternfly-theme/package.json
@@ -58,7 +58,7 @@
     "typescript": "^5.9.3",
     "uniforms-bridge-simple-schema-2": "^3.10.2",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0",
     "webpack-node-externals": "^3.0.0"

--- a/packages/import-java-classes-component/package.json
+++ b/packages/import-java-classes-component/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^29.1.5",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/kogito-data-index-webapp/package.json
+++ b/packages/kogito-data-index-webapp/package.json
@@ -30,7 +30,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/kogito-jobs-service-webapp/package.json
+++ b/packages/kogito-jobs-service-webapp/package.json
@@ -30,7 +30,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.9.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -106,7 +106,7 @@
     "uuid": "^14.0.0",
     "waait": "^1.0.5",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/runtime-tools-process-dev-ui-webapp/package.json
+++ b/packages/runtime-tools-process-dev-ui-webapp/package.json
@@ -95,7 +95,7 @@
     "url": "^0.11.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/serverless-logic-web-tools/package.json
+++ b/packages/serverless-logic-web-tools/package.json
@@ -139,7 +139,7 @@
     "typescript": "^5.9.3",
     "vscode-languageserver-textdocument": "^1.0.4",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/serverless-logic-web-tools/webpack.config.ts
+++ b/packages/serverless-logic-web-tools/webpack.config.ts
@@ -182,7 +182,7 @@ export default async (webpackEnv: any, webpackArgv: any) => {
         ignoreWarnings: [/Failed to parse source map/],
       }),
       devServer: {
-        https: true,
+        server: "https",
         historyApiFallback: false,
         static: [{ directory: path.join(__dirname, "./dist") }, { directory: path.join(__dirname, "./static") }],
         compress: true,

--- a/packages/serverless-workflow-combined-editor/package.json
+++ b/packages/serverless-workflow-combined-editor/package.json
@@ -67,7 +67,7 @@
     "typescript": "^5.9.3",
     "vscode-json-languageservice": "^4.2.1",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/serverless-workflow-dev-ui-webapp/package.json
+++ b/packages/serverless-workflow-dev-ui-webapp/package.json
@@ -93,7 +93,7 @@
     "url": "^0.11.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/serverless-workflow-editor/package.json
+++ b/packages/serverless-workflow-editor/package.json
@@ -106,7 +106,7 @@
     "ts-jest": "^29.1.5",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/serverless-workflow-standalone-editor/package.json
+++ b/packages/serverless-workflow-standalone-editor/package.json
@@ -78,7 +78,7 @@
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.16.0",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0",
     "yaml-language-server-parser": "^0.1.3"

--- a/packages/serverless-workflow-text-editor/package.json
+++ b/packages/serverless-workflow-text-editor/package.json
@@ -58,7 +58,7 @@
     "typescript": "^5.9.3",
     "vscode-json-languageservice": "^4.2.1",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -82,7 +82,7 @@
     "typescript": "^5.9.3",
     "vscode-extension-tester": "^8.10.0",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/sonataflow-deployment-webapp/package.json
+++ b/packages/sonataflow-deployment-webapp/package.json
@@ -74,7 +74,7 @@
     "ts-jest": "^29.1.5",
     "url": "^0.11.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/sonataflow-management-console-webapp/package.json
+++ b/packages/sonataflow-management-console-webapp/package.json
@@ -108,7 +108,7 @@
     "url": "^0.11.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/sonataflow-uniforms/package.json
+++ b/packages/sonataflow-uniforms/package.json
@@ -55,7 +55,7 @@
     "typescript": "^5.9.3",
     "uniforms-bridge-simple-schema-2": "^3.10.2",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/uniforms-patternfly/package.json
+++ b/packages/uniforms-patternfly/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.9.3",
     "uniforms-bridge-simple-schema-2": "^3.10.2",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/xyflow-react-kie-diagram/package.json
+++ b/packages/xyflow-react-kie-diagram/package.json
@@ -47,7 +47,7 @@
     "storybook": "^8.4.2",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/yard-editor/package.json
+++ b/packages/yard-editor/package.json
@@ -66,7 +66,7 @@
     "start-server-and-test": "^2.0.3",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/packages/yard-vscode-extension/package.json
+++ b/packages/yard-vscode-extension/package.json
@@ -73,7 +73,7 @@
     "typescript": "^5.9.3",
     "vscode-extension-tester": "^8.10.0",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.10.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-merge": "^5.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,13 +189,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -258,13 +258,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -309,13 +309,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -519,13 +519,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -625,13 +625,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -673,13 +673,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -758,13 +758,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -859,13 +859,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1137,13 +1137,13 @@ importers:
         version: 3.17.2
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1255,10 +1255,10 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1459,13 +1459,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1578,13 +1578,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1709,13 +1709,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1785,13 +1785,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1864,13 +1864,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1937,13 +1937,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -2034,13 +2034,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -2125,13 +2125,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -2246,13 +2246,13 @@ importers:
         version: 4.2.1
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -2428,13 +2428,13 @@ importers:
         version: 4.2.1
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -2528,13 +2528,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -3180,13 +3180,13 @@ importers:
         version: 3.10.2(react@17.0.2)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -3485,13 +3485,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -4107,13 +4107,13 @@ importers:
         version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.0)(typescript@5.9.3)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -4270,13 +4270,13 @@ importers:
         version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.0)(typescript@5.9.3)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -4413,13 +4413,13 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@5.104.1))(webpack@5.104.1)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -5358,13 +5358,13 @@ importers:
         version: 1.0.5
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -5590,13 +5590,13 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@5.104.1))(webpack@5.104.1)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -6811,13 +6811,13 @@ importers:
         version: 1.0.7
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -7071,13 +7071,13 @@ importers:
         version: 4.2.1
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -7286,13 +7286,13 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@5.104.1))(webpack@5.104.1)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -7520,7 +7520,7 @@ importers:
         version: 8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^8.4.2
-        version: 8.6.18(@swc/core@1.3.92)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@4.10.0)
+        version: 8.6.18(@swc/core@1.3.92)(esbuild@0.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@5.1.4)
       '@types/d3-drag':
         specifier: ^3.0.3
         version: 3.0.7
@@ -7589,19 +7589,19 @@ importers:
         version: 8.6.18(prettier@3.3.2)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.25.9)(jest@29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -7994,13 +7994,13 @@ importers:
         version: 3.17.2
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -8112,13 +8112,13 @@ importers:
         version: 4.2.1
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -8272,13 +8272,13 @@ importers:
         version: 8.10.0(mocha@10.6.0)(typescript@5.9.3)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -8466,13 +8466,13 @@ importers:
         version: 0.11.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -8882,13 +8882,13 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@5.104.1))(webpack@5.104.1)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -9043,13 +9043,13 @@ importers:
         version: 3.10.2(react@17.0.2)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -9103,10 +9103,10 @@ importers:
         version: 8.6.18(storybook@8.6.18(prettier@3.3.2))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.5
-        version: 3.0.5(webpack@5.104.1(esbuild@0.25.9))
+        version: 3.0.5(webpack@5.104.1)
       '@storybook/react-webpack5':
         specifier: ^8.4.2
-        version: 8.6.18(esbuild@0.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
+        version: 8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
       '@storybook/theming':
         specifier: ^8.4.2
         version: 8.6.14(storybook@8.6.18(prettier@3.3.2))
@@ -9124,7 +9124,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(esbuild@0.25.9)
+        version: 5.104.1
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -9344,13 +9344,13 @@ importers:
         version: 3.10.2(react@17.0.2)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -9900,13 +9900,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -10106,13 +10106,13 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -10372,13 +10372,13 @@ importers:
         version: 8.10.0(mocha@10.6.0)(typescript@5.9.3)
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(webpack-cli@4.10.0)
+        version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        specifier: ^5.1.4
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server:
         specifier: ^5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -10436,7 +10436,7 @@ importers:
         version: 7.28.3(@babel/core@7.28.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3))
+        version: 29.7.0(@types/node@24.13.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.0)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -14580,11 +14580,11 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@swc/counter@0.1.2':
-    resolution: {integrity: sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==}
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/types@0.1.5':
-    resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -15371,21 +15371,26 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@webpack-cli/configtest@1.2.0':
-    resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
+  '@webpack-cli/configtest@2.1.1':
+    resolution: {integrity: sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: 4.x.x || 5.x.x
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
 
-  '@webpack-cli/info@1.5.0':
-    resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
+  '@webpack-cli/info@2.0.2':
+    resolution: {integrity: sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
 
-  '@webpack-cli/serve@1.7.0':
-    resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
+  '@webpack-cli/serve@2.0.5':
+    resolution: {integrity: sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
       webpack-dev-server: '*'
     peerDependenciesMeta:
       webpack-dev-server:
@@ -16785,6 +16790,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
@@ -17867,8 +17876,8 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
-  envinfo@7.8.1:
-    resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
+  envinfo@7.21.0:
+    resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
     engines: {node: '>=4'}
     hasBin: true
 
@@ -18405,8 +18414,9 @@ packages:
     resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
     hasBin: true
 
-  fastest-levenshtein@1.0.12:
-    resolution: {integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==}
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastq@1.8.0:
     resolution: {integrity: sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==}
@@ -19262,6 +19272,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -19320,9 +19335,9 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  interpret@2.2.0:
-    resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
-    engines: {node: '>= 0.10'}
+  interpret@3.1.1:
+    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
+    engines: {node: '>=10.13.0'}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -22558,9 +22573,9 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
-  rechoir@0.7.0:
-    resolution: {integrity: sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==}
-    engines: {node: '>= 0.10'}
+  rechoir@0.8.0:
+    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
+    engines: {node: '>= 10.13.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -22999,6 +23014,11 @@ packages:
 
   semver@7.8.2:
     resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.3:
+    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -24586,20 +24606,17 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  webpack-cli@4.10.0:
-    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
-    engines: {node: '>=10.13.0'}
+  webpack-cli@5.1.4:
+    resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
+    engines: {node: '>=14.15.0'}
     hasBin: true
     peerDependencies:
       '@webpack-cli/generators': '*'
-      '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x
+      webpack: 5.x.x
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
       '@webpack-cli/generators':
-        optional: true
-      '@webpack-cli/migrate':
         optional: true
       webpack-bundle-analyzer:
         optional: true
@@ -30720,14 +30737,6 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.18(prettier@3.3.2)
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.104.1(esbuild@0.25.9))':
-    dependencies:
-      '@babel/core': 7.28.3
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.104.1(esbuild@0.25.9))
-    transitivePeerDependencies:
-      - supports-color
-      - webpack
-
   '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.104.1)':
     dependencies:
       '@babel/core': 7.28.3
@@ -30754,7 +30763,7 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@storybook/builder-webpack5@8.6.18(@swc/core@1.3.92)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@4.10.0)':
+  '@storybook/builder-webpack5@8.6.18(@swc/core@1.3.92)(esbuild@0.25.9)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 8.6.18(storybook@8.6.18(prettier@3.3.2))
       '@types/semver': 7.7.1
@@ -30772,12 +30781,12 @@ snapshots:
       semver: 7.8.2
       storybook: 8.6.18(prettier@3.3.2)
       style-loader: 3.3.3(webpack@5.104.1)
-      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(webpack@5.104.1)
+      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(esbuild@0.25.9)(webpack@5.104.1)
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.3(webpack@5.104.1)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.6.2
@@ -30790,7 +30799,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@8.6.18(esbuild@0.25.9)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@8.6.18(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)':
     dependencies:
       '@storybook/core-webpack': 8.6.18(storybook@8.6.18(prettier@3.3.2))
       '@types/semver': 7.7.1
@@ -30798,23 +30807,23 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.104.1(esbuild@0.25.9))
+      css-loader: 6.7.1(webpack@5.104.1)
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.9))
-      html-webpack-plugin: 5.6.4(webpack@5.104.1(esbuild@0.25.9))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1)
+      html-webpack-plugin: 5.6.4(webpack@5.104.1)
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.8.2
       storybook: 8.6.18(prettier@3.3.2)
-      style-loader: 3.3.3(webpack@5.104.1(esbuild@0.25.9))
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.9)(webpack@5.104.1(esbuild@0.25.9))
+      style-loader: 3.3.3(webpack@5.104.1)
+      terser-webpack-plugin: 5.3.16(webpack@5.104.1)
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.104.1(esbuild@0.25.9)
-      webpack-dev-middleware: 6.1.3(webpack@5.104.1(esbuild@0.25.9))
+      webpack: 5.104.1
+      webpack-dev-middleware: 6.1.3(webpack@5.104.1)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -30876,7 +30885,7 @@ snapshots:
     dependencies:
       storybook: 8.6.18(prettier@3.3.2)
 
-  '@storybook/preset-react-webpack@8.6.18(@swc/core@1.3.92)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@4.10.0)':
+  '@storybook/preset-react-webpack@8.6.18(@swc/core@1.3.92)(esbuild@0.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 8.6.18(storybook@8.6.18(prettier@3.3.2))
       '@storybook/react': 8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
@@ -30891,7 +30900,7 @@ snapshots:
       semver: 7.8.2
       storybook: 8.6.18(prettier@3.3.2)
       tsconfig-paths: 4.2.0
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -30902,11 +30911,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preset-react-webpack@8.6.18(esbuild@0.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)':
     dependencies:
       '@storybook/core-webpack': 8.6.18(storybook@8.6.18(prettier@3.3.2))
       '@storybook/react': 8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.9))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)
       '@types/semver': 7.7.1
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -30917,7 +30926,7 @@ snapshots:
       semver: 7.8.2
       storybook: 8.6.18(prettier@3.3.2)
       tsconfig-paths: 4.2.0
-      webpack: 5.104.1(esbuild@0.25.9)
+      webpack: 5.104.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -30936,20 +30945,6 @@ snapshots:
     dependencies:
       storybook: 8.6.18(prettier@3.3.2)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.9))':
-    dependencies:
-      debug: 4.4.3
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.0.4
-      micromatch: 4.0.8
-      react-docgen-typescript: 2.2.2(typescript@5.9.3)
-      tslib: 2.8.1
-      typescript: 5.9.3
-      webpack: 5.104.1(esbuild@0.25.9)
-    transitivePeerDependencies:
-      - supports-color
-
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)':
     dependencies:
       debug: 4.4.3
@@ -30960,7 +30955,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -30970,10 +30965,10 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       storybook: 8.6.18(prettier@3.3.2)
 
-  '@storybook/react-webpack5@8.6.18(@swc/core@1.3.92)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@4.10.0)':
+  '@storybook/react-webpack5@8.6.18(@swc/core@1.3.92)(esbuild@0.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@5.1.4)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.18(@swc/core@1.3.92)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@4.10.0)
-      '@storybook/preset-react-webpack': 8.6.18(@swc/core@1.3.92)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@4.10.0)
+      '@storybook/builder-webpack5': 8.6.18(@swc/core@1.3.92)(esbuild@0.25.9)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 8.6.18(@swc/core@1.3.92)(esbuild@0.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)(webpack-cli@5.1.4)
       '@storybook/react': 8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -30989,10 +30984,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-webpack5@8.6.18(esbuild@0.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)':
+  '@storybook/react-webpack5@8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.18(esbuild@0.25.9)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 8.6.18(esbuild@0.25.9)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 8.6.18(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
       '@storybook/react': 8.6.18(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.18(prettier@3.3.2))(typescript@5.9.3)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -31149,8 +31144,8 @@ snapshots:
 
   '@swc/core@1.3.92':
     dependencies:
-      '@swc/counter': 0.1.2
-      '@swc/types': 0.1.5
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.3.92
       '@swc/core-darwin-x64': 1.3.92
@@ -31164,10 +31159,12 @@ snapshots:
       '@swc/core-win32-x64-msvc': 1.3.92
     optional: true
 
-  '@swc/counter@0.1.2':
+  '@swc/counter@0.1.3':
     optional: true
 
-  '@swc/types@0.1.5':
+  '@swc/types@0.1.26':
+    dependencies:
+      '@swc/counter': 0.1.3
     optional: true
 
   '@szmarczak/http-timer@4.0.6':
@@ -32156,25 +32153,27 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.104.1)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:
-      webpack: 5.104.1(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack: 5.104.1(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:
-      envinfo: 7.8.1
-      webpack-cli: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack: 5.104.1(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
 
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.4)(webpack@5.104.1)':
     dependencies:
-      webpack-cli: 4.10.0(webpack@5.104.1)
-
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0)(webpack-dev-server@5.2.4)':
-    dependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack: 5.104.1(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
     optionalDependencies:
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
+
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.104.1)':
+    dependencies:
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.104.1)
 
   '@whatwg-node/events@0.0.2': {}
 
@@ -32347,7 +32346,7 @@ snapshots:
       lodash: 4.18.1
       micromatch: 4.0.8
       p-limit: 2.3.0
-      semver: 7.8.2
+      semver: 7.8.3
       strip-ansi: 6.0.1
       tar: 6.2.1
       tinylogic: 2.0.0
@@ -33121,19 +33120,12 @@ snapshots:
       find-up: 5.0.0
       webpack: 5.104.1(@swc/core@1.3.92)
 
-  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.104.1(esbuild@0.25.9)):
-    dependencies:
-      '@babel/core': 7.28.3
-      find-cache-dir: 4.0.0
-      schema-utils: 4.3.3
-      webpack: 5.104.1(esbuild@0.25.9)
-
   babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.104.1):
     dependencies:
       '@babel/core': 7.28.3
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
 
   babel-plugin-emotion@10.2.2:
     dependencies:
@@ -34134,6 +34126,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@10.0.1: {}
+
   commander@12.1.0: {}
 
   commander@14.0.3: {}
@@ -34297,7 +34291,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@5.1.4)
 
   copy-webpack-plugin@13.0.1(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
@@ -34480,7 +34474,7 @@ snapshots:
       cheerio: 1.0.0-rc.10
       html-webpack-plugin: 5.6.4(webpack@5.104.1)
       lodash: 4.18.1
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@5.1.4)
 
   css-declaration-sorter@7.2.0(postcss@8.5.6):
     dependencies:
@@ -34498,19 +34492,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.7.4
-      webpack: 5.104.1(webpack-cli@4.10.0)
-
-  css-loader@6.7.1(webpack@5.104.1(esbuild@0.25.9)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      postcss-value-parser: 4.2.0
-      semver: 7.8.2
-      webpack: 5.104.1(esbuild@0.25.9)
+      webpack: 5.104.1(webpack-cli@5.1.4)
 
   css-loader@6.7.1(webpack@5.104.1):
     dependencies:
@@ -34522,7 +34504,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.8.2
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
 
   css-loader@7.1.2(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
@@ -34545,7 +34527,7 @@ snapshots:
       postcss: 8.5.6
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   css-select@4.3.0:
     dependencies:
@@ -35390,7 +35372,7 @@ snapshots:
 
   env-paths@2.2.1: {}
 
-  envinfo@7.8.1: {}
+  envinfo@7.21.0: {}
 
   environment@1.1.0: {}
 
@@ -36170,7 +36152,7 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
 
-  fastest-levenshtein@1.0.12: {}
+  fastest-levenshtein@1.0.16: {}
 
   fastq@1.8.0:
     dependencies:
@@ -36225,7 +36207,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   file-selector@0.4.0:
     dependencies:
@@ -36241,7 +36223,7 @@ snapshots:
       is-glob: 4.0.3
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   filename-reserved-regex@2.0.0: {}
 
@@ -36380,23 +36362,6 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.9)):
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 7.0.1
-      deepmerge: 4.2.2
-      fs-extra: 10.1.0
-      memfs: 3.5.1
-      minimatch: 3.1.5
-      node-abort-controller: 3.1.1
-      schema-utils: 3.3.0
-      semver: 7.8.2
-      tapable: 2.3.0
-      typescript: 5.9.3
-      webpack: 5.104.1(esbuild@0.25.9)
-
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -36412,7 +36377,7 @@ snapshots:
       semver: 7.8.2
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
 
   form-data-encoder@4.0.2: {}
 
@@ -36953,16 +36918,6 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.3.92)
     optional: true
 
-  html-webpack-plugin@5.6.4(webpack@5.104.1(esbuild@0.25.9)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.23
-      pretty-error: 4.0.0
-      tapable: 2.3.0
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.9)
-
   html-webpack-plugin@5.6.4(webpack@5.104.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -36971,7 +36926,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@5.1.4)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -37231,6 +37186,11 @@ snapshots:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -37286,7 +37246,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  interpret@2.2.0: {}
+  interpret@3.1.1: {}
 
   invariant@2.2.4:
     dependencies:
@@ -39160,7 +39120,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   minimalistic-assert@1.0.1: {}
 
@@ -39322,7 +39282,7 @@ snapshots:
       loader-utils: 2.0.4
       monaco-editor: 0.39.0
       monaco-yaml: 4.0.4(monaco-editor@0.39.0)
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   monaco-editor@0.39.0: {}
 
@@ -39562,7 +39522,7 @@ snapshots:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.8.2
+      semver: 7.8.3
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -39595,7 +39555,7 @@ snapshots:
       url: 0.11.3
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   node-releases@2.0.27: {}
 
@@ -40762,7 +40722,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   rc-config-loader@4.1.3:
     dependencies:
@@ -41218,9 +41178,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  rechoir@0.7.0:
+  rechoir@0.8.0:
     dependencies:
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   redent@3.0.0:
     dependencies:
@@ -41704,6 +41664,8 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.2: {}
+
+  semver@7.8.3: {}
 
   send@0.19.0:
     dependencies:
@@ -42390,15 +42352,11 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(webpack-cli@4.10.0)
-
-  style-loader@3.3.3(webpack@5.104.1(esbuild@0.25.9)):
-    dependencies:
-      webpack: 5.104.1(esbuild@0.25.9)
+      webpack: 5.104.1(webpack-cli@5.1.4)
 
   style-loader@3.3.3(webpack@5.104.1):
     dependencies:
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
 
   stylehacks@6.1.1(postcss@8.5.6):
     dependencies:
@@ -42600,6 +42558,18 @@ snapshots:
       '@swc/core': 1.3.92
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.16(@swc/core@1.3.92)(esbuild@0.25.9)(webpack@5.104.1):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.46.0
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
+    optionalDependencies:
+      '@swc/core': 1.3.92
+      esbuild: 0.25.9
+
   terser-webpack-plugin@5.3.16(@swc/core@1.3.92)(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -42618,20 +42588,9 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.3.92
-
-  terser-webpack-plugin@5.3.16(esbuild@0.25.9)(webpack@5.104.1(esbuild@0.25.9)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.46.0
-      webpack: 5.104.1(esbuild@0.25.9)
-    optionalDependencies:
-      esbuild: 0.25.9
 
   terser-webpack-plugin@5.3.16(webpack@5.104.1):
     dependencies:
@@ -42640,7 +42599,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1
+      webpack: 5.104.1(webpack-cli@5.1.4)
 
   terser@5.43.1:
     dependencies:
@@ -42859,6 +42818,25 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.28.3)
       esbuild: 0.15.13
 
+  ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.25.9)(jest@29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.4
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.3
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.3)
+      esbuild: 0.25.9
+
   ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
@@ -42912,7 +42890,7 @@ snapshots:
       micromatch: 4.0.8
       semver: 7.7.4
       typescript: 5.9.3
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@5.1.4)
 
   ts-log@2.2.5: {}
 
@@ -43274,7 +43252,7 @@ snapshots:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@5.1.4)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.104.1)
 
@@ -43715,49 +43693,41 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-cli@4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1):
+  webpack-cli@5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.104.1)
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)(webpack-dev-server@5.2.4)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.104.1)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.104.1)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.4)(webpack@5.104.1)
       colorette: 2.0.20
-      commander: 7.2.0
+      commander: 10.0.1
       cross-spawn: 7.0.6
-      fastest-levenshtein: 1.0.12
-      import-local: 3.0.2
-      interpret: 2.2.0
-      rechoir: 0.7.0
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      envinfo: 7.21.0
+      fastest-levenshtein: 1.0.16
+      import-local: 3.2.0
+      interpret: 3.1.1
+      rechoir: 0.8.0
+      webpack: 5.104.1(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
 
-  webpack-cli@4.10.0(webpack@5.104.1):
+  webpack-cli@5.1.4(webpack@5.104.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.104.1)
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.104.1)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.104.1)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.104.1)
       colorette: 2.0.20
-      commander: 7.2.0
+      commander: 10.0.1
       cross-spawn: 7.0.6
-      fastest-levenshtein: 1.0.12
-      import-local: 3.0.2
-      interpret: 2.2.0
-      rechoir: 0.7.0
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      envinfo: 7.21.0
+      fastest-levenshtein: 1.0.16
+      import-local: 3.2.0
+      interpret: 3.1.1
+      rechoir: 0.8.0
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
-
-  webpack-dev-middleware@6.1.3(webpack@5.104.1(esbuild@0.25.9)):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.1
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.3.3
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.9)
 
   webpack-dev-middleware@6.1.3(webpack@5.104.1):
     dependencies:
@@ -43767,7 +43737,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4)
 
   webpack-dev-middleware@7.4.2(tslib@2.8.1)(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
@@ -43791,7 +43761,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - tslib
 
@@ -43834,7 +43804,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@4.10.0)(webpack@5.104.1):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -43865,8 +43835,8 @@ snapshots:
       webpack-dev-middleware: 7.4.2(tslib@2.8.1)(webpack@5.104.1)
       ws: 8.19.0
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack: 5.104.1(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -44046,7 +44016,41 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0):
+  webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(webpack-cli@5.1.4):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.19.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(esbuild@0.25.9)(webpack@5.104.1)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
+    optionalDependencies:
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -44074,45 +44078,13 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     optionalDependencies:
-      webpack-cli: 4.10.0(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
 
-  webpack@5.104.1(esbuild@0.25.9):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.9)(webpack@5.104.1(esbuild@0.25.9))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.104.1(webpack-cli@4.10.0):
+  webpack@5.104.1(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -44140,7 +44112,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -44465,7 +44437,7 @@ snapshots:
 
   zip-webpack-plugin@4.0.1(webpack-sources@3.3.3)(webpack@5.104.1):
     dependencies:
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@5.1.4)
       webpack-sources: 3.3.3
       yazl: 2.5.1
 


### PR DESCRIPTION
After the webpack-dev-server update I'm not able to start SLWT locally as it's required to update webpack-cli to >5.0.0:
https://github.com/webpack/webpack-dev-server/blob/main/migration-v5.md
my error is:
```
$ cd packages/serverless-logic-web-tools; pnpm start:dev-webapp
...
[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'running'. These properties are valid:
   object { allowedHosts?, bonjour?, client?, compress?, devMiddleware?, headers?, historyApiFallback?, host?, hot?, ipc?, liveReload?, onListening?, open?, port?, proxy?, server?, app?, setupExitSignals?, setupMiddlewares?, static?, watchFiles?, webSocketServer? }
 ELIFECYCLE  Command failed with exit code 2.
 ```
Currently we have "webpack-cli": "^4.10.0" this PR is to update to v 5