### PR TITLE
SRVLOGIC-812: Kubesmarts not able to start a workflow

### DIFF
--- a/packages/serverless-logic-web-tools/src/runtimeTools/pages/RuntimeToolsWorkflowDefinitions.tsx
+++ b/packages/serverless-logic-web-tools/src/runtimeTools/pages/RuntimeToolsWorkflowDefinitions.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { WorkflowDefinitionListContainer } from "@kie-tools/runtime-tools-swf-webapp-components/dist/WorkflowDefinitionListContainer";
 import { Card } from "@patternfly/react-core/dist/esm/components/Card";
 import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
@@ -26,11 +26,16 @@ import { useNavigate } from "react-router-dom";
 import { routes } from "../../navigation/Routes";
 import { WorkflowDefinition } from "@kie-tools/runtime-tools-swf-gateway-api/dist/types";
 import { CloudEventPageSource } from "@kie-tools/runtime-tools-swf-webapp-components/dist/CloudEventForm";
+import { useSettings } from "../../settings/SettingsContext";
+import { changeUrlOrigin } from "../../url";
 
 const PAGE_TITLE = "Workflow Definitions";
 
 export function RuntimeToolsWorkflowDefinitions() {
   const navigate = useNavigate();
+  const settings = useSettings();
+
+  const dataIndexUrlOrigin = useMemo(() => new URL(settings.runtimeTools.config.dataIndexUrl).origin, [settings]);
 
   const onOpenWorkflowForm = useCallback(
     (workflowDefinition: WorkflowDefinition) => {
@@ -42,14 +47,14 @@ export function RuntimeToolsWorkflowDefinitions() {
           state: {
             workflowDefinition: {
               workflowName: workflowDefinition.workflowName,
-              endpoint: workflowDefinition.endpoint,
-              serviceUrl: workflowDefinition.serviceUrl,
+              endpoint: changeUrlOrigin(workflowDefinition.endpoint, dataIndexUrlOrigin),
+              serviceUrl: changeUrlOrigin(workflowDefinition.serviceUrl, dataIndexUrlOrigin),
             },
           },
         }
       );
     },
-    [navigate]
+    [navigate, dataIndexUrlOrigin]
   );
 
   const onOpenTriggerCloudEventForWorkflow = useCallback(
@@ -64,15 +69,15 @@ export function RuntimeToolsWorkflowDefinitions() {
           state: {
             workflowDefinition: {
               workflowName: workflowDefinition.workflowName,
-              endpoint: workflowDefinition.endpoint,
-              serviceUrl: workflowDefinition.serviceUrl,
+              endpoint: changeUrlOrigin(workflowDefinition.endpoint, dataIndexUrlOrigin),
+              serviceUrl: changeUrlOrigin(workflowDefinition.serviceUrl, dataIndexUrlOrigin),
             },
             source: CloudEventPageSource.DEFINITIONS,
           },
         }
       );
     },
-    [navigate]
+    [navigate, dataIndexUrlOrigin]
   );
 
   return (

--- a/packages/serverless-logic-web-tools/src/url/index.ts
+++ b/packages/serverless-logic-web-tools/src/url/index.ts
@@ -35,3 +35,21 @@ export function isDataIndexUrlValid(url: string): boolean {
     return false;
   }
 }
+
+/**
+ * Changes the origin (protocol, hostname, and port) of a URL while preserving the path.
+ *
+ * @param url - The URL with the origin to be changed
+ * @param newOrigin - The origin to be applied to the URL. If a full URL is passed, only the origin will be used.
+ * @returns The URL with the changed origin (e.g., "https://my-app.openshift.com/hello_world")
+ */
+export function changeUrlOrigin(url: string, newOrigin: string): string {
+  const newOriginUrl = new URL(newOrigin);
+  const urlObj = new URL(url);
+
+  urlObj.protocol = newOriginUrl.protocol;
+  urlObj.hostname = newOriginUrl.hostname;
+  urlObj.port = newOriginUrl.port;
+
+  return urlObj.toString();
+}

--- a/packages/serverless-logic-web-tools/tests/url/changeUrlOrigin.test.ts
+++ b/packages/serverless-logic-web-tools/tests/url/changeUrlOrigin.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { changeUrlOrigin } from "../../src/url";
+
+describe("changeUrlOrigin", () => {
+  it.each([
+    ["http://localhost:8080/", "https://my-app.openshift.com", "https://my-app.openshift.com/"],
+    ["http://localhost:8080/hello_world", "https://my-app.openshift.com", "https://my-app.openshift.com/hello_world"],
+    ["http://localhost:8080/hello_world", "https://my-app.openshift.com/", "https://my-app.openshift.com/hello_world"],
+    ["http://localhost:8080/workflow", "https://example.com:9090/data-index", "https://example.com:9090/workflow"],
+    [
+      "http://wrong-address.it/workflow?param=value",
+      "https://my-app.com/graphql",
+      "https://my-app.com/workflow?param=value",
+    ],
+    ["http://localhost:8080/workflow#section", "https://my-app.com/graphql", "https://my-app.com/workflow#section"],
+    [
+      "http://localhost:8080/api/v1/workflows/hello",
+      "https://prod.example.com:8443",
+      "https://prod.example.com:8443/api/v1/workflows/hello",
+    ],
+    ["http://example.com/path", "https://example.com/other", "https://example.com/path"],
+    [
+      "http://localhost:8080/hello_world",
+      "https://dev-12345-000-demo-username-dev.apps.rm3.7wse.p1.openshiftapps.com/graphql",
+      "https://dev-12345-000-demo-username-dev.apps.rm3.7wse.p1.openshiftapps.com/hello_world",
+    ],
+  ])("should change URL origin from '%s' with new origin '%s' to '%s'", (url, newOrigin, expectedUrl) => {
+    expect(changeUrlOrigin(url, newOrigin)).toBe(expectedUrl);
+  });
+
+  it.each([
+    ["", "https://example.com"],
+    ["http://localhost:8080/path", ""],
+    ["not-a-valid-url", "https://example.com"],
+    ["http://localhost:8080/path", "not-a-valid-url"],
+  ])("should throw error for invalid inputs: url='%s', newOrigin='%s'", (url, newOrigin) => {
+    expect(() => changeUrlOrigin(url, newOrigin)).toThrow();
+  });
+});


### PR DESCRIPTION
**Jira:** https://redhat.atlassian.net/browse/SRVLOGIC-812

**Description:**
Kubesmarts Runtime Tools are not able to start a Workflow

**Steps to replicate:**

https://start.kubesmarts.org/dev/

1. Connect it to OpenShift with the DevMode enabled (normal deployments are also affected)
2. Wait for the deployment to be ready 
3. From OpenShift copy the URL of the deployment
4. in kubesmarts, go to: https://start.kubesmarts.org/dev/#/settings/runtime-tools
5. Ad [deployment URL]/graphql
6. See the message "Your Runtime Tools connection information is set."
7. https://start.kubesmarts.org/dev/#/runtime-tools/workflow-definitions
8. Click on Start for "hello_world"
9. Click on Start

**Expected result:**
The workflow started successfully.

**My understanding:**
- `0.32.0` version was not affected
- In PR https://github.com/apache/incubator-kie-tools/pull/2302 , using `kogitoServiceUrl` to contact the right endpoint
- Possibly after some update in the Quarkus configuration, the data-index is returning the internal Kubernetes service URL instead of the public OpenShift route

Preview:
https://github.com/user-attachments/assets/6f97a16d-2600-4e73-b365-2c07aa2fed4c

https://github.com/user-attachments/assets/5e8e7993-e329-4d70-b8f3-9f6c504e225c


