### PR TITLE
[SRVLOGIC-1054] Use Red Hat rbac-proxy image directly

### DIFF
--- a/packages/osl-operator-bundle-image/env/index.js
+++ b/packages/osl-operator-bundle-image/env/index.js
@@ -40,11 +40,6 @@ module.exports = composeEnv([rootEnv, redHatEnv, sonataflowOperatorEnv], {
       default: rootEnv.env.root.streamName,
       description: "The image tag.",
     },
-    OSL_OPERATOR_BUNDLE__proxyImage: {
-      default:
-        "registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56",
-      description: "Internal proxy image for the Operator Manager Proxy Pod. Must come from a valid Red Hat registry.",
-    },
     OSL_OPERATOR_BUNDLE__namespace: {
       default: "logic-operator-system",
       description: "Namespace name for the installation bundle",
@@ -62,7 +57,6 @@ module.exports = composeEnv([rootEnv, redHatEnv, sonataflowOperatorEnv], {
         name: getOrDefault(this.vars.OSL_OPERATOR_BUNDLE_IMAGE__name),
         buildTag: getOrDefault(this.vars.OSL_OPERATOR_BUNDLE_IMAGE__buildTag),
         version: rootEnv.env.root.version,
-        proxyImage: getOrDefault(this.vars.OSL_OPERATOR_BUNDLE__proxyImage),
         namespace: getOrDefault(this.vars.OSL_OPERATOR_BUNDLE__namespace),
         namePrefix: getOrDefault(this.vars.OSL_OPERATOR_BUNDLE__namePrefix),
       },

--- a/packages/osl-operator-bundle-image/package.json
+++ b/packages/osl-operator-bundle-image/package.json
@@ -30,7 +30,7 @@
     "manifests:copy": "pnpm manifests:copy:operator && pnpm manifests:copy:resources",
     "manifests:copy:operator": "OP_PATH=node_modules/@kie-tools/sonataflow-operator && cp -R ${OP_PATH}/config dist/ && cp -R ${OP_PATH}/bin dist/ && mkdir -p dist/bundle/manifests && cp ${OP_PATH}/bundle/manifests/sonataflow.org_sonataflow* dist/bundle/manifests/ && rm -rf dist/config/manifests/bases/*.yaml && cp ${OP_PATH}/Makefile dist/ && cp -R ${OP_PATH}/hack dist/ && cp ${OP_PATH}/PROJECT dist/",
     "manifests:copy:resources": "cp -R resources/config dist/",
-    "manifests:update": ". ./node_modules/@osl/redhat-python-venv/venv/bin/activate && python resources/scripts/update_manifests.py $(build-env oslOperatorBundleImage.namespace) $(build-env oslOperatorBundleImage.namePrefix) $(build-env oslOperatorBundleImage.proxyImage)"
+    "manifests:update": ". ./node_modules/@osl/redhat-python-venv/venv/bin/activate && python resources/scripts/update_manifests.py $(build-env oslOperatorBundleImage.namespace) $(build-env oslOperatorBundleImage.namePrefix)"
   },
   "dependencies": {
     "@kie-tools/root-env": "workspace:*",

--- a/packages/osl-operator-bundle-image/resources/scripts/update_manifests.py
+++ b/packages/osl-operator-bundle-image/resources/scripts/update_manifests.py
@@ -4,7 +4,6 @@ from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 KUSTOMIZATION_DEFAULT_PATH = "dist/config/default/kustomization.yaml"
 KUSTOMIZATION_MANIFESTS_PATH = "dist/config/manifests/kustomization.yaml"
-DEPLOYMENT_PATCH_PATH = "dist/config/default/manager_auth_proxy_patch.yaml"
 CONTROLLERS_CONFIG_PATH = "dist/config/manager/controllers_cfg.yaml"
 
 def update_default_kustomization(new_namespace, new_name_prefix):
@@ -45,30 +44,6 @@ def replace_csv_prefix(resource, new_csv_prefix):
         return resource.replace("sonataflow-operator", new_csv_prefix)
     return resource
 
-def update_proxy_image(new_image):
-    yaml = ruamel.yaml.YAML()
-    yaml.preserve_quotes = True
-
-    with open(DEPLOYMENT_PATCH_PATH, "r") as f:
-        deployment = yaml.load(f)
-
-    containers = deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
-    updated = False
-    for container in containers:
-        if container.get("name") == "kube-rbac-proxy":
-            container["image"] = new_image
-            updated = True
-            break
-
-    if not updated:
-        print("kube-rbac-proxy container not found in deployment.")
-        sys.exit(1)
-
-    with open(DEPLOYMENT_PATCH_PATH, "w") as f:
-        yaml.dump(deployment, f)
-
-    print(f"{DEPLOYMENT_PATCH_PATH} image updated to '{new_image}'.")
-
 def update_controllers_cfg(new_name_prefix):
     yaml = ruamel.yaml.YAML(typ="rt")
     yaml.preserve_quotes = True
@@ -92,15 +67,13 @@ def update_controllers_cfg(new_name_prefix):
     print(f'{CONTROLLERS_CONFIG_PATH} was updated setting builderConfigMapName to "{new_name_prefix}-builder-config"')
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        print("Usage: python update_manifests.py <new_namespace> <new_name_prefix> <proxy_image>")
+    if len(sys.argv) != 3:
+        print("Usage: python update_manifests.py <new_namespace> <new_name_prefix>")
         sys.exit(1)
 
     new_namespace = sys.argv[1]
     new_name_prefix = sys.argv[2]
-    proxy_image = sys.argv[3]
 
     update_default_kustomization(new_namespace, new_name_prefix)
     update_manifests_kustomization(new_name_prefix)
-    update_proxy_image(proxy_image)
     update_controllers_cfg(new_name_prefix)

--- a/packages/sonataflow-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/packages/sonataflow-operator/config/default/manager_auth_proxy_patch.yaml
@@ -27,10 +27,10 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: quay.io/brancz/kube-rbac-proxy:v0.13.1
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
           env:
             - name: RELATED_IMAGE_KUBE_RBAC_PROXY
-              value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/packages/sonataflow-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/packages/sonataflow-operator/config/default/manager_auth_proxy_patch.yaml
@@ -27,10 +27,10 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:09dd98dddb689e0ec546d52c360ced5b2e2592211880761b454e98ab503e3eef
           env:
             - name: RELATED_IMAGE_KUBE_RBAC_PROXY
-              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
+              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:09dd98dddb689e0ec546d52c360ced5b2e2592211880761b454e98ab503e3eef
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1054

- Removes custom handling of the rbac-proxy image and uses the Red Hat one directly. 
- Updates the version of the rbac-image to the latest available. 

This would also enable to remove a step in the cutoff process as the image was updated during the cutoff (probably manually). 