### PR TITLE
[NO-ISSUE] Remove maven-core from the bundled m2 repo in the images.

### DIFF
--- a/packages/sonataflow-image-common/resources/modules/sonataflow/common/build/added/cleanup_project.sh
+++ b/packages/sonataflow-image-common/resources/modules/sonataflow/common/build/added/cleanup_project.sh
@@ -37,5 +37,9 @@ find "${KOGITO_HOME}"/.m2/repository -name '_*.repositories' -type f -delete
 find "${KOGITO_HOME}"/.m2/repository -name '*.lastUpdated' -type f -delete
 
 # Remove files that include build timestamps to have reproducible images
-find "${KOGITO_HOME}"/.m2/ -name resolver-status.properties -delete 
+find "${KOGITO_HOME}"/.m2/ -name resolver-status.properties -delete
+
+# Remove maven-core from local repo.
+# Plugins declare it with provided scope; the Maven runtime supplies it.
+rm -rf "${KOGITO_HOME}"/.m2/repository/org/apache/maven/maven-core
 


### PR DESCRIPTION
There is a vulnerability with maven-core library reported by Quay.io. I found out that the library is a dependency in some Maven plugins, declared with provided scope. However maven resolves it during the build. So when a m2 repository is packed for the images, it gets in, even when it is actually not used at all, because maven-core from the actual Maven distribution in the image is used. The modification in the script should remove the library before it gets packed into the m2 archive for the images. 