### PR TITLE
[SRVLOGIC-1070] Use github.token instead of a custom one.

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -35,10 +35,11 @@ env:
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
   KOGITO_RUNTIME_version: "111-SNAPSHOT"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
-  MAVEN_REPO_TOKEN: ${{ secrets.LOGIC_MAVEN_REPOSITORY_ACCESS_TOKEN }}
+  MAVEN_REPO_TOKEN: ${{ github.token }}
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   run:

--- a/.github/workflows/ci_build_full.yml
+++ b/.github/workflows/ci_build_full.yml
@@ -31,10 +31,11 @@ env:
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
   KOGITO_RUNTIME_version: "111-SNAPSHOT"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
-  MAVEN_REPO_TOKEN: ${{ secrets.LOGIC_MAVEN_REPOSITORY_ACCESS_TOKEN }}
+  MAVEN_REPO_TOKEN: ${{ github.token }}
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   run:

--- a/.github/workflows/ci_build_midstream.yml
+++ b/.github/workflows/ci_build_midstream.yml
@@ -27,11 +27,12 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 env:
   KOGITO_RUNTIME_version: "111-SNAPSHOT"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
-  MAVEN_REPO_TOKEN: ${{ secrets.LOGIC_MAVEN_REPOSITORY_ACCESS_TOKEN }}
+  MAVEN_REPO_TOKEN: ${{ github.token }}
 
 jobs:
   build:

--- a/.github/workflows/kubesmarts_build_and_publish.yml
+++ b/.github/workflows/kubesmarts_build_and_publish.yml
@@ -41,7 +41,7 @@ on:
 env:
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/kie-tools/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   GITHUB_TOKEN: ${{ secrets.KIE1_TOKEN }}
-  MAVEN_REPO_TOKEN: ${{ secrets.LOGIC_MAVEN_REPOSITORY_ACCESS_TOKEN }}
+  MAVEN_REPO_TOKEN: ${{ github.token }}
   KIE_TOOLS_BUILD__buildContainerImages: "false"
   KIE_TOOLS_BUILD__runEndToEndTests: "false"
   KIE_TOOLS_BUILD__runLinters: "false"

--- a/.github/workflows/osl_export_images.yml
+++ b/.github/workflows/osl_export_images.yml
@@ -10,7 +10,7 @@ on:
 env:
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   GITHUB_TOKEN: ${{ secrets.KIE1_TOKEN }}
-  MAVEN_REPO_TOKEN: ${{ secrets.LOGIC_MAVEN_REPOSITORY_ACCESS_TOKEN }}
+  MAVEN_REPO_TOKEN: ${{ github.token }}
   PNPM_FILTER: ${{ vars.OSL_IMAGES_PNPM_FILTER }}
   OSL_PACKAGES: ${{ vars.OSL_IMAGES_PACKAGES }}
 

--- a/.github/workflows/osl_publish_images_snapshots.yml
+++ b/.github/workflows/osl_publish_images_snapshots.yml
@@ -33,10 +33,11 @@ on:
 
 env:
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
-  MAVEN_REPO_TOKEN: ${{ secrets.LOGIC_MAVEN_REPOSITORY_ACCESS_TOKEN }}
+  MAVEN_REPO_TOKEN: ${{ github.token }}
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   publish_images_snapshots:

--- a/.github/workflows/osl_sync_main.yml
+++ b/.github/workflows/osl_sync_main.yml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
-  MAVEN_REPO_TOKEN: ${{ secrets.LOGIC_MAVEN_REPOSITORY_ACCESS_TOKEN }}
+  MAVEN_REPO_TOKEN: ${{ github.token }}
 
 concurrency:
   group: sync-main


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1070

The right combination is to use github.token set with permissions section, loaded into a custom variable and then using that custom variable in settings.xml servers section. Directly using env.GITHUB_TOKEN in the past didn't work for settings.xml properly. Also using organizational or repository secret doesn't work in PRs created from forks, because it is restricted by GitHub. 