### PR TITLE
[SRVLOGIC-1067] Change parent in Maven modules to relative path.

### DIFF
--- a/packages/dev-deployment-base-image/pom.xml
+++ b/packages/dev-deployment-base-image/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.kie</groupId>
     <artifactId>kie-tools-maven-base</artifactId>
     <version>111-SNAPSHOT</version>
-    <relativePath>./node_modules/@kie-tools/maven-base/pom.xml</relativePath>
+    <relativePath>../maven-base/pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/packages/jbpm-quarkus-devui/pom.xml
+++ b/packages/jbpm-quarkus-devui/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.kie</groupId>
     <artifactId>kie-tools-maven-base</artifactId>
     <version>111-SNAPSHOT</version>
-    <relativePath>./node_modules/@kie-tools/maven-base/pom.xml</relativePath>
+    <relativePath>../maven-base/pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.kie</groupId>
     <artifactId>kie-tools-maven-base</artifactId>
     <version>111-SNAPSHOT</version>
-    <relativePath>./node_modules/@kie-tools/maven-base/pom.xml</relativePath>
+    <relativePath>../maven-base/pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/packages/yard-model/pom.xml
+++ b/packages/yard-model/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.kie</groupId>
     <artifactId>kie-tools-maven-base</artifactId>
     <version>111-SNAPSHOT</version>
-    <relativePath>./node_modules/@kie-tools/maven-base/pom.xml</relativePath>
+    <relativePath>../maven-base/pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/packages/yard-validator-worker/pom.xml
+++ b/packages/yard-validator-worker/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.kie</groupId>
     <artifactId>kie-tools-maven-base</artifactId>
     <version>111-SNAPSHOT</version>
-    <relativePath>./node_modules/@kie-tools/maven-base/pom.xml</relativePath>
+    <relativePath>../maven-base/pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1067

Removes occurrences of referencing parent pom using node modules. This had been breaking the Maven build order when using the profile build-all-maven-artifacts. 