### PR TITLE
[NO-ISSUE] Revert setup-maven-cache action reference.

### DIFF
--- a/.github/actions/setup-kie-tools/action.yml
+++ b/.github/actions/setup-kie-tools/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Setup local maven cache
       if: inputs.USE_REMOTE_ARTIFACTS == 'false'
       id: setup_maven_cache
-      uses: ./.github/actions/setup-maven-cache
+      uses: kubesmarts/kie-tools/.github/actions/setup-maven-cache@main
       with:
         DEPS_BRANCHNAME: ${{ inputs.DEPS_BRANCHNAME }}
         WORKING_DIR: ${{ inputs.WORKING_DIR }}


### PR DESCRIPTION
Removes the change in the setup-maven-cache action reference. In the workflow kubesmarts_daily_dev_publish.yml there are two repositories checked out along each other and the new reference doesn't work in that case. 