### PR TITLE
[NO-ISSUE] Fix image names for quay.io.

### DIFF
--- a/packages/kogito-data-index-ephemeral-image/env/index.js
+++ b/packages/kogito-data-index-ephemeral-image/env/index.js
@@ -25,15 +25,15 @@ const sonataflowImageCommonEnv = require("@kie-tools/sonataflow-image-common/env
 module.exports = composeEnv([rootEnv, sonataflowImageCommonEnv], {
   vars: varsWithName({
     KOGITO_DATA_INDEX_EPHEMERAL_IMAGE__registry: {
-      default: "registry.redhat.io",
+      default: "quay.io",
       description: "The image registry.",
     },
     KOGITO_DATA_INDEX_EPHEMERAL_IMAGE__account: {
-      default: "openshift-serverless-1",
+      default: "kubesmarts",
       description: "The image registry account.",
     },
     KOGITO_DATA_INDEX_EPHEMERAL_IMAGE__name: {
-      default: "logic-data-index-ephemeral-rhel9",
+      default: "incubator-kie-kogito-data-index-ephemeral",
       description: "The image name.",
     },
     KOGITO_DATA_INDEX_EPHEMERAL_IMAGE__buildTag: {

--- a/packages/kogito-data-index-postgresql-image/env/index.js
+++ b/packages/kogito-data-index-postgresql-image/env/index.js
@@ -25,15 +25,15 @@ const sonataflowImageCommonEnv = require("@kie-tools/sonataflow-image-common/env
 module.exports = composeEnv([rootEnv, sonataflowImageCommonEnv], {
   vars: varsWithName({
     KOGITO_DATA_INDEX_POSTGRESQL_IMAGE__registry: {
-      default: "registry.redhat.io",
+      default: "quay.io",
       description: "The image registry.",
     },
     KOGITO_DATA_INDEX_POSTGRESQL_IMAGE__account: {
-      default: "openshift-serverless-1",
+      default: "kubesmarts",
       description: "The image registry account.",
     },
     KOGITO_DATA_INDEX_POSTGRESQL_IMAGE__name: {
-      default: "logic-data-index-postgresql-rhel9",
+      default: "incubator-kie-kogito-data-index-postgresql",
       description: "The image name.",
     },
     KOGITO_DATA_INDEX_POSTGRESQL_IMAGE__buildTag: {

--- a/packages/kogito-db-migrator-tool-image/env/index.js
+++ b/packages/kogito-db-migrator-tool-image/env/index.js
@@ -25,15 +25,15 @@ const sonataflowImageCommonEnv = require("@kie-tools/sonataflow-image-common/env
 module.exports = composeEnv([rootEnv, sonataflowImageCommonEnv], {
   vars: varsWithName({
     KOGITO_DB_MIGRATOR_TOOL_IMAGE__registry: {
-      default: "registry.redhat.io",
+      default: "quay.io",
       description: "The image registry.",
     },
     KOGITO_DB_MIGRATOR_TOOL_IMAGE__account: {
-      default: "openshift-serverless-1",
+      default: "kubesmarts",
       description: "The image registry account.",
     },
     KOGITO_DB_MIGRATOR_TOOL_IMAGE__name: {
-      default: "logic-db-migrator-tool-rhel9",
+      default: "kie-kogito-db-migrator-tool",
       description: "The image name.",
     },
     KOGITO_DB_MIGRATOR_TOOL_IMAGE__buildTag: {

--- a/packages/kogito-jobs-service-ephemeral-image/env/index.js
+++ b/packages/kogito-jobs-service-ephemeral-image/env/index.js
@@ -25,15 +25,15 @@ const sonataflowImageCommonEnv = require("@kie-tools/sonataflow-image-common/env
 module.exports = composeEnv([rootEnv, sonataflowImageCommonEnv], {
   vars: varsWithName({
     KOGITO_JOBS_SERVICE_EPHEMERAL_IMAGE__registry: {
-      default: "registry.redhat.io",
+      default: "quay.io",
       description: "The image registry.",
     },
     KOGITO_JOBS_SERVICE_EPHEMERAL_IMAGE__account: {
-      default: "openshift-serverless-1",
+      default: "kubesmarts",
       description: "The image registry account.",
     },
     KOGITO_JOBS_SERVICE_EPHEMERAL_IMAGE__name: {
-      default: "logic-jobs-service-ephemeral-rhel9",
+      default: "incubator-kie-kogito-jobs-service-ephemeral",
       description: "The image name.",
     },
     KOGITO_JOBS_SERVICE_EPHEMERAL_IMAGE__buildTag: {

--- a/packages/kogito-jobs-service-postgresql-image/env/index.js
+++ b/packages/kogito-jobs-service-postgresql-image/env/index.js
@@ -25,15 +25,15 @@ const sonataflowImageCommonEnv = require("@kie-tools/sonataflow-image-common/env
 module.exports = composeEnv([rootEnv, sonataflowImageCommonEnv], {
   vars: varsWithName({
     KOGITO_JOBS_SERVICE_POSTGRESQL_IMAGE__registry: {
-      default: "registry.redhat.io",
+      default: "quay.io",
       description: "The image registry.",
     },
     KOGITO_JOBS_SERVICE_POSTGRESQL_IMAGE__account: {
-      default: "openshift-serverless-1",
+      default: "kubesmarts",
       description: "The image registry account.",
     },
     KOGITO_JOBS_SERVICE_POSTGRESQL_IMAGE__name: {
-      default: "logic-jobs-service-postgresql-rhel9",
+      default: "incubator-kie-kogito-jobs-service-postgresql",
       description: "The image name.",
     },
     KOGITO_JOBS_SERVICE_POSTGRESQL_IMAGE__buildTag: {

--- a/packages/sonataflow-builder-image/env/index.js
+++ b/packages/sonataflow-builder-image/env/index.js
@@ -29,15 +29,15 @@ const sonataflowImageCommonEnv = require("@kie-tools/sonataflow-image-common/env
 module.exports = composeEnv([rootEnv, sonataflowImageCommonEnv], {
   vars: varsWithName({
     SONATAFLOW_BUILDER_IMAGE__registry: {
-      default: "registry.redhat.io",
+      default: "quay.io",
       description: "The image registry.",
     },
     SONATAFLOW_BUILDER_IMAGE__account: {
-      default: "openshift-serverless-1",
+      default: "kubesmarts",
       description: "The image registry account.",
     },
     SONATAFLOW_BUILDER_IMAGE__name: {
-      default: "logic-swf-builder-rhel9",
+      default: "incubator-kie-sonataflow-builder",
       description: "The image name.",
     },
     SONATAFLOW_BUILDER_IMAGE__buildTag: {

--- a/packages/sonataflow-devmode-image/env/index.js
+++ b/packages/sonataflow-devmode-image/env/index.js
@@ -30,15 +30,15 @@ const rootEnv = require("@kie-tools/root-env/env");
 module.exports = composeEnv([rootEnv, sonataflowImageCommonEnv], {
   vars: varsWithName({
     SONATAFLOW_DEVMODE_IMAGE__registry: {
-      default: "registry.redhat.io",
+      default: "quay.io",
       description: "E.g., `docker.io` or `quay.io`.",
     },
     SONATAFLOW_DEVMODE_IMAGE__account: {
-      default: "openshift-serverless-1",
+      default: "kubesmarts",
       description: "E.g,. `apache` or `kie-tools-bot`",
     },
     SONATAFLOW_DEVMODE_IMAGE__name: {
-      default: "logic-swf-devmode-rhel9",
+      default: "incubator-kie-sonataflow-devmode",
       description: "Name of the image itself.",
     },
     SONATAFLOW_DEVMODE_IMAGE__buildTag: {


### PR DESCRIPTION
Updates the change of default image names from https://github.com/kubesmarts/kie-tools/pull/360 to point to quay.io images. 

Quay.io publishing test run passed: https://github.com/kubesmarts/kie-tools/actions/runs/28862558251