### PR TITLE
Revert temporary jdtls URL workaround.

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -68,7 +68,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://kubesmarts.github.io/jdtls-repository-custom/1.43.0</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.43.0/repository</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This reverts a temporary workaround as the Eclipse jdtls repository issue has been fixed (the repository got restored): https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3823