### PR TITLE
[NO-ISSUE] Re-generate the operator.xml descriptor after the bupm of kubernetes APIs bump

### DIFF
--- a/packages/sonataflow-operator/config/manager/kustomization.yaml
+++ b/packages/sonataflow-operator/config/manager/kustomization.yaml
@@ -35,9 +35,8 @@ configMapGenerator:
       - controllers_cfg.yaml
     name: controllers-config
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind:
-  Kustomization
-  # Changed during "make build", do not attempt to modify it manually!
+kind: Kustomization
+# Changed during "make build", do not attempt to modify it manually!
 images:
   - name: controller
     newName: docker.io/apache/incubator-kie-sonataflow-operator

--- a/packages/sonataflow-operator/container-builder/common/registry_docker.go
+++ b/packages/sonataflow-operator/container-builder/common/registry_docker.go
@@ -104,7 +104,7 @@ func (d DockerLocalRegistry) StartRegistry() string {
 	}
 
 	createOpts := client.ContainerCreateOptions{
-		Name:  RegistryImg,
+		Name: RegistryImg,
 		Config: &container.Config{
 			Image:        registryImgFullTag,
 			ExposedPorts: exposedPorts,

--- a/packages/sonataflow-operator/operator.yaml
+++ b/packages/sonataflow-operator/operator.yaml
@@ -93,7 +93,9 @@ spec:
                       a Container.
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -149,6 +151,43 @@ spec:
                                 type: string
                             required:
                               - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing
+                                  the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
@@ -212,7 +251,9 @@ spec:
                       a Container.
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -268,6 +309,43 @@ spec:
                                 type: string
                             required:
                               - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing
+                                  the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
@@ -332,7 +410,7 @@ spec:
                         Claims lists the names of resources, defined in spec.resourceClaims,
                         that are used by this container.
 
-                        This is an alpha field and requires enabling the
+                        This field depends on the
                         DynamicResourceAllocation feature gate.
 
                         This field is immutable. It can only be set for containers.
@@ -681,8 +759,9 @@ spec:
                               in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -738,6 +817,43 @@ spec:
                                         type: string
                                     required:
                                       - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing
+                                          the env file.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                      - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -802,8 +918,9 @@ spec:
                               in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -859,6 +976,43 @@ spec:
                                         type: string
                                     required:
                                       - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing
+                                          the env file.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                      - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -924,7 +1078,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -1590,7 +1744,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                   Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -1605,7 +1758,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                   Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -1774,7 +1926,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                               Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -1789,7 +1940,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                               Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -1884,8 +2034,8 @@ spec:
                                         most preferred is the one with the greatest sum of weights, i.e.
                                         for each node that meets all of the scheduling requirements (resource
                                         request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                        compute a sum by iterating through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                        compute a sum by iterating through the elements of this field and subtracting
+                                        "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                         node(s) with the highest sum are the most preferred.
                                       items:
                                         description: The weights of all of the matched
@@ -1956,7 +2106,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                   Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -1971,7 +2120,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                   Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -2140,7 +2288,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                               Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -2155,7 +2302,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                               Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -2282,8 +2428,9 @@ spec:
                                       present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
                                         type: string
                                       value:
                                         description: |-
@@ -2340,6 +2487,43 @@ spec:
                                                 type: string
                                             required:
                                               - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                              - volumeName
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
@@ -2409,7 +2593,7 @@ spec:
                                     Cannot be updated.
                                   items:
                                     description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
+                                      of a set of ConfigMaps or Secrets
                                     properties:
                                       configMapRef:
                                         description: The ConfigMap to select from
@@ -2430,8 +2614,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                        description: |-
+                                          Optional text to prepend to the name of each environment variable.
+                                          May consist of any printable ASCII characters except '='.
                                         type: string
                                       secretRef:
                                         description: The Secret to select from
@@ -2481,8 +2666,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to execute
+                                            in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -2497,8 +2682,8 @@ spec:
                                               x-kubernetes-list-type: atomic
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request
-                                            to perform.
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
                                           properties:
                                             host:
                                               description: |-
@@ -2548,9 +2733,8 @@ spec:
                                             - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before being
-                                            terminated.
+                                          description: Sleep represents a duration that
+                                            the container should sleep.
                                           properties:
                                             seconds:
                                               description: Seconds is the number of
@@ -2563,8 +2747,8 @@ spec:
                                         tcpSocket:
                                           description: |-
                                             Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
                                           properties:
                                             host:
                                               description: "Optional: Host name to connect
@@ -2596,8 +2780,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to execute
+                                            in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -2612,8 +2796,8 @@ spec:
                                               x-kubernetes-list-type: atomic
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request
-                                            to perform.
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
                                           properties:
                                             host:
                                               description: |-
@@ -2663,9 +2847,8 @@ spec:
                                             - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before being
-                                            terminated.
+                                          description: Sleep represents a duration that
+                                            the container should sleep.
                                           properties:
                                             seconds:
                                               description: Seconds is the number of
@@ -2678,8 +2861,8 @@ spec:
                                         tcpSocket:
                                           description: |-
                                             Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
                                           properties:
                                             host:
                                               description: "Optional: Host name to connect
@@ -2698,6 +2881,12 @@ spec:
                                             - port
                                           type: object
                                       type: object
+                                    stopSignal:
+                                      description: |-
+                                        StopSignal defines which signal will be sent to a container when it is being stopped.
+                                        If not specified, the default is defined by the container runtime in use.
+                                        StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                      type: string
                                   type: object
                                 livenessProbe:
                                   description: |-
@@ -2707,7 +2896,8 @@ spec:
                                     More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
+                                      description: Exec specifies a command to execute
+                                        in the container.
                                       properties:
                                         command:
                                           description: |-
@@ -2728,8 +2918,7 @@ spec:
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
                                       properties:
                                         port:
                                           description: Port number of the gRPC service.
@@ -2748,7 +2937,7 @@ spec:
                                         - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
+                                      description: HTTPGet specifies an HTTP GET request
                                         to perform.
                                       properties:
                                         host:
@@ -2816,8 +3005,8 @@ spec:
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
                                       properties:
                                         host:
                                           description: "Optional: Host name to connect
@@ -2916,7 +3105,8 @@ spec:
                                     More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
+                                      description: Exec specifies a command to execute
+                                        in the container.
                                       properties:
                                         command:
                                           description: |-
@@ -2937,8 +3127,7 @@ spec:
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
                                       properties:
                                         port:
                                           description: Port number of the gRPC service.
@@ -2957,7 +3146,7 @@ spec:
                                         - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
+                                      description: HTTPGet specifies an HTTP GET request
                                         to perform.
                                       properties:
                                         host:
@@ -3025,8 +3214,8 @@ spec:
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
                                       properties:
                                         host:
                                           description: "Optional: Host name to connect
@@ -3099,7 +3288,7 @@ spec:
                                         Claims lists the names of resources, defined in spec.resourceClaims,
                                         that are used by this container.
 
-                                        This is an alpha field and requires enabling the
+                                        This field depends on the
                                         DynamicResourceAllocation feature gate.
 
                                         This field is immutable. It can only be set for containers.
@@ -3226,7 +3415,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -3357,7 +3545,8 @@ spec:
                                     More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
+                                      description: Exec specifies a command to execute
+                                        in the container.
                                       properties:
                                         command:
                                           description: |-
@@ -3378,8 +3567,7 @@ spec:
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
                                       properties:
                                         port:
                                           description: Port number of the gRPC service.
@@ -3398,7 +3586,7 @@ spec:
                                         - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
+                                      description: HTTPGet specifies an HTTP GET request
                                         to perform.
                                       properties:
                                         host:
@@ -3466,8 +3654,8 @@ spec:
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
                                       properties:
                                         host:
                                           description: "Optional: Host name to connect
@@ -3683,8 +3871,9 @@ spec:
                                         variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable.
-                                            Must be a C_IDENTIFIER.
+                                          description: |-
+                                            Name of the environment variable.
+                                            May consist of any printable ASCII characters except '='.
                                           type: string
                                         value:
                                           description: |-
@@ -3741,6 +3930,43 @@ spec:
                                                   type: string
                                               required:
                                                 - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              description: |-
+                                                FileKeyRef selects a key of the env file.
+                                                Requires the EnvFiles feature gate to be enabled.
+                                              properties:
+                                                key:
+                                                  description: |-
+                                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  description: |-
+                                                    Specify whether the file or its key must be defined. If the file or key
+                                                    does not exist, then the env var is not published.
+                                                    If optional is set to true and the specified key does not exist,
+                                                    the environment variable will not be set in the Pod's containers.
+
+                                                    If optional is set to false and the specified key does not exist,
+                                                    an error will be returned during Pod creation.
+                                                  type: boolean
+                                                path:
+                                                  description: |-
+                                                    The path within the volume from which to select the file.
+                                                    Must be relative and may not contain the '..' path or start with '..'.
+                                                  type: string
+                                                volumeName:
+                                                  description: The name of the volume
+                                                    mount containing the env file.
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -3806,14 +4032,14 @@ spec:
                                   envFrom:
                                     description: |-
                                       List of sources to populate environment variables in the container.
-                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      When a key exists in multiple
                                       sources, the value associated with the last source will take precedence.
                                       Values defined by an Env with a duplicate key will take precedence.
                                       Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -3834,9 +4060,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be a
-                                            C_IDENTIFIER.
+                                          description: |-
+                                            Optional text to prepend to the name of each environment variable.
+                                            May consist of any printable ASCII characters except '='.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -3887,8 +4113,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
-                                            description: Exec specifies the action to
-                                              take.
+                                            description: Exec specifies a command to
+                                              execute in the container.
                                             properties:
                                               command:
                                                 description: |-
@@ -3903,7 +4129,7 @@ spec:
                                                 x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
+                                            description: HTTPGet specifies an HTTP GET
                                               request to perform.
                                             properties:
                                               host:
@@ -3957,9 +4183,8 @@ spec:
                                               - port
                                             type: object
                                           sleep:
-                                            description: Sleep represents the duration
-                                              that the container should sleep before
-                                              being terminated.
+                                            description: Sleep represents a duration
+                                              that the container should sleep.
                                             properties:
                                               seconds:
                                                 description: Seconds is the number of
@@ -3972,8 +4197,8 @@ spec:
                                           tcpSocket:
                                             description: |-
                                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                              for the backward compatibility. There are no validation of this field and
-                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                              for backward compatibility. There is no validation of this field and
+                                              lifecycle hooks will fail at runtime when it is specified.
                                             properties:
                                               host:
                                                 description: "Optional: Host name to
@@ -4005,8 +4230,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
-                                            description: Exec specifies the action to
-                                              take.
+                                            description: Exec specifies a command to
+                                              execute in the container.
                                             properties:
                                               command:
                                                 description: |-
@@ -4021,7 +4246,7 @@ spec:
                                                 x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
+                                            description: HTTPGet specifies an HTTP GET
                                               request to perform.
                                             properties:
                                               host:
@@ -4075,9 +4300,8 @@ spec:
                                               - port
                                             type: object
                                           sleep:
-                                            description: Sleep represents the duration
-                                              that the container should sleep before
-                                              being terminated.
+                                            description: Sleep represents a duration
+                                              that the container should sleep.
                                             properties:
                                               seconds:
                                                 description: Seconds is the number of
@@ -4090,8 +4314,8 @@ spec:
                                           tcpSocket:
                                             description: |-
                                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                              for the backward compatibility. There are no validation of this field and
-                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                              for backward compatibility. There is no validation of this field and
+                                              lifecycle hooks will fail at runtime when it is specified.
                                             properties:
                                               host:
                                                 description: "Optional: Host name to
@@ -4110,6 +4334,12 @@ spec:
                                               - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        description: |-
+                                          StopSignal defines which signal will be sent to a container when it is being stopped.
+                                          If not specified, the default is defined by the container runtime in use.
+                                          StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     description: |-
@@ -4119,7 +4349,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -4140,8 +4371,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -4160,7 +4390,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -4229,8 +4459,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -4335,7 +4565,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -4356,8 +4587,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -4376,7 +4606,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -4445,8 +4675,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -4487,7 +4717,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -4519,7 +4751,7 @@ spec:
                                           Claims lists the names of resources, defined in spec.resourceClaims,
                                           that are used by this container.
 
-                                          This is an alpha field and requires enabling the
+                                          This field depends on the
                                           DynamicResourceAllocation feature gate.
 
                                           This field is immutable. It can only be set for containers.
@@ -4574,10 +4806,10 @@ spec:
                                   restartPolicy:
                                     description: |-
                                       RestartPolicy defines the restart behavior of individual containers in a pod.
-                                      This field may only be set for init containers, and the only allowed value is "Always".
-                                      For non-init containers or when this field is not specified,
+                                      This overrides the pod-level restart policy. When this field is not specified,
                                       the restart behavior is defined by the Pod's restart policy and the container type.
-                                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                      Additionally, setting the RestartPolicy as "Always" for the init container will
+                                      have the following effect:
                                       this init container will be continually restarted on
                                       exit until all regular containers have terminated. Once all regular
                                       containers have completed, all init containers with restartPolicy "Always"
@@ -4589,6 +4821,59 @@ spec:
                                       init container is started, or after any startupProbe has successfully
                                       completed.
                                     type: string
+                                  restartPolicyRules:
+                                    description: |-
+                                      Represents a list of rules to be checked to determine if the
+                                      container should be restarted on exit. The rules are evaluated in
+                                      order. Once a rule matches a container exit condition, the remaining
+                                      rules are ignored. If no rule matches the container exit condition,
+                                      the Container-level restart policy determines the whether the container
+                                      is restarted or not. Constraints on the rules:
+                                      - At most 20 rules are allowed.
+                                      - Rules can have the same action.
+                                      - Identical rules are not forbidden in validations.
+                                      When rules are specified, container MUST set RestartPolicy explicitly
+                                      even it if matches the Pod's RestartPolicy.
+                                    items:
+                                      description: ContainerRestartRule describes how
+                                        a container exit is handled.
+                                      properties:
+                                        action:
+                                          description: |-
+                                            Specifies the action taken on a container exit if the requirements
+                                            are satisfied. The only possible value is "Restart" to restart the
+                                            container.
+                                          type: string
+                                        exitCodes:
+                                          description: Represents the exit codes to
+                                            check on container exits.
+                                          properties:
+                                            operator:
+                                              description: |-
+                                                Represents the relationship between the container exit code(s) and the
+                                                specified values. Possible values are:
+                                                - In: the requirement is satisfied if the container exit code is in the
+                                                  set of specified values.
+                                                - NotIn: the requirement is satisfied if the container exit code is
+                                                  not in the set of specified values.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                Specifies the set of values to check for container exit codes.
+                                                At most 255 elements are allowed.
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                            - operator
+                                          type: object
+                                      required:
+                                        - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     description: |-
                                       SecurityContext defines the security options the container should be run with.
@@ -4664,7 +4949,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -4795,7 +5079,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -4816,8 +5101,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -4836,7 +5120,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -4905,8 +5189,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -5118,9 +5402,13 @@ spec:
                                       options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
+                                        description: |-
+                                          Name is this DNS resolver option's name.
+                                          Required.
                                         type: string
                                       value:
+                                        description: Value is this DNS resolver option's
+                                          value.
                                         type: string
                                     type: object
                                   type: array
@@ -5283,8 +5571,9 @@ spec:
                                         variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable.
-                                            Must be a C_IDENTIFIER.
+                                          description: |-
+                                            Name of the environment variable.
+                                            May consist of any printable ASCII characters except '='.
                                           type: string
                                         value:
                                           description: |-
@@ -5341,6 +5630,43 @@ spec:
                                                   type: string
                                               required:
                                                 - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              description: |-
+                                                FileKeyRef selects a key of the env file.
+                                                Requires the EnvFiles feature gate to be enabled.
+                                              properties:
+                                                key:
+                                                  description: |-
+                                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  description: |-
+                                                    Specify whether the file or its key must be defined. If the file or key
+                                                    does not exist, then the env var is not published.
+                                                    If optional is set to true and the specified key does not exist,
+                                                    the environment variable will not be set in the Pod's containers.
+
+                                                    If optional is set to false and the specified key does not exist,
+                                                    an error will be returned during Pod creation.
+                                                  type: boolean
+                                                path:
+                                                  description: |-
+                                                    The path within the volume from which to select the file.
+                                                    Must be relative and may not contain the '..' path or start with '..'.
+                                                  type: string
+                                                volumeName:
+                                                  description: The name of the volume
+                                                    mount containing the env file.
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -5406,14 +5732,14 @@ spec:
                                   envFrom:
                                     description: |-
                                       List of sources to populate environment variables in the container.
-                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      When a key exists in multiple
                                       sources, the value associated with the last source will take precedence.
                                       Values defined by an Env with a duplicate key will take precedence.
                                       Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -5434,9 +5760,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be a
-                                            C_IDENTIFIER.
+                                          description: |-
+                                            Optional text to prepend to the name of each environment variable.
+                                            May consist of any printable ASCII characters except '='.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -5487,8 +5813,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
-                                            description: Exec specifies the action to
-                                              take.
+                                            description: Exec specifies a command to
+                                              execute in the container.
                                             properties:
                                               command:
                                                 description: |-
@@ -5503,7 +5829,7 @@ spec:
                                                 x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
+                                            description: HTTPGet specifies an HTTP GET
                                               request to perform.
                                             properties:
                                               host:
@@ -5557,9 +5883,8 @@ spec:
                                               - port
                                             type: object
                                           sleep:
-                                            description: Sleep represents the duration
-                                              that the container should sleep before
-                                              being terminated.
+                                            description: Sleep represents a duration
+                                              that the container should sleep.
                                             properties:
                                               seconds:
                                                 description: Seconds is the number of
@@ -5572,8 +5897,8 @@ spec:
                                           tcpSocket:
                                             description: |-
                                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                              for the backward compatibility. There are no validation of this field and
-                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                              for backward compatibility. There is no validation of this field and
+                                              lifecycle hooks will fail at runtime when it is specified.
                                             properties:
                                               host:
                                                 description: "Optional: Host name to
@@ -5605,8 +5930,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
-                                            description: Exec specifies the action to
-                                              take.
+                                            description: Exec specifies a command to
+                                              execute in the container.
                                             properties:
                                               command:
                                                 description: |-
@@ -5621,7 +5946,7 @@ spec:
                                                 x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
+                                            description: HTTPGet specifies an HTTP GET
                                               request to perform.
                                             properties:
                                               host:
@@ -5675,9 +6000,8 @@ spec:
                                               - port
                                             type: object
                                           sleep:
-                                            description: Sleep represents the duration
-                                              that the container should sleep before
-                                              being terminated.
+                                            description: Sleep represents a duration
+                                              that the container should sleep.
                                             properties:
                                               seconds:
                                                 description: Seconds is the number of
@@ -5690,8 +6014,8 @@ spec:
                                           tcpSocket:
                                             description: |-
                                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                              for the backward compatibility. There are no validation of this field and
-                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                              for backward compatibility. There is no validation of this field and
+                                              lifecycle hooks will fail at runtime when it is specified.
                                             properties:
                                               host:
                                                 description: "Optional: Host name to
@@ -5710,6 +6034,12 @@ spec:
                                               - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        description: |-
+                                          StopSignal defines which signal will be sent to a container when it is being stopped.
+                                          If not specified, the default is defined by the container runtime in use.
+                                          StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     description: |-
@@ -5719,7 +6049,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -5740,8 +6071,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -5760,7 +6090,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -5829,8 +6159,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -5935,7 +6265,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -5956,8 +6287,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -5976,7 +6306,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -6045,8 +6375,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -6087,7 +6417,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -6119,7 +6451,7 @@ spec:
                                           Claims lists the names of resources, defined in spec.resourceClaims,
                                           that are used by this container.
 
-                                          This is an alpha field and requires enabling the
+                                          This field depends on the
                                           DynamicResourceAllocation feature gate.
 
                                           This field is immutable. It can only be set for containers.
@@ -6174,10 +6506,10 @@ spec:
                                   restartPolicy:
                                     description: |-
                                       RestartPolicy defines the restart behavior of individual containers in a pod.
-                                      This field may only be set for init containers, and the only allowed value is "Always".
-                                      For non-init containers or when this field is not specified,
+                                      This overrides the pod-level restart policy. When this field is not specified,
                                       the restart behavior is defined by the Pod's restart policy and the container type.
-                                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                      Additionally, setting the RestartPolicy as "Always" for the init container will
+                                      have the following effect:
                                       this init container will be continually restarted on
                                       exit until all regular containers have terminated. Once all regular
                                       containers have completed, all init containers with restartPolicy "Always"
@@ -6189,6 +6521,59 @@ spec:
                                       init container is started, or after any startupProbe has successfully
                                       completed.
                                     type: string
+                                  restartPolicyRules:
+                                    description: |-
+                                      Represents a list of rules to be checked to determine if the
+                                      container should be restarted on exit. The rules are evaluated in
+                                      order. Once a rule matches a container exit condition, the remaining
+                                      rules are ignored. If no rule matches the container exit condition,
+                                      the Container-level restart policy determines the whether the container
+                                      is restarted or not. Constraints on the rules:
+                                      - At most 20 rules are allowed.
+                                      - Rules can have the same action.
+                                      - Identical rules are not forbidden in validations.
+                                      When rules are specified, container MUST set RestartPolicy explicitly
+                                      even it if matches the Pod's RestartPolicy.
+                                    items:
+                                      description: ContainerRestartRule describes how
+                                        a container exit is handled.
+                                      properties:
+                                        action:
+                                          description: |-
+                                            Specifies the action taken on a container exit if the requirements
+                                            are satisfied. The only possible value is "Restart" to restart the
+                                            container.
+                                          type: string
+                                        exitCodes:
+                                          description: Represents the exit codes to
+                                            check on container exits.
+                                          properties:
+                                            operator:
+                                              description: |-
+                                                Represents the relationship between the container exit code(s) and the
+                                                specified values. Possible values are:
+                                                - In: the requirement is satisfied if the container exit code is in the
+                                                  set of specified values.
+                                                - NotIn: the requirement is satisfied if the container exit code is
+                                                  not in the set of specified values.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                Specifies the set of values to check for container exit codes.
+                                                At most 255 elements are allowed.
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                            - operator
+                                          type: object
+                                      required:
+                                        - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     description: |-
                                       SecurityContext defines the security options the container should be run with.
@@ -6264,7 +6649,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -6395,7 +6779,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -6416,8 +6801,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -6436,7 +6820,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -6505,8 +6889,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -6855,6 +7239,14 @@ spec:
 
                                   It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                   Containers that need access to the ResourceClaim reference it with this name.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                  belongs to a PodGroup, a PodResourceClaim is matched to a
+                                  PodGroupResourceClaim if all of their fields are equal (Name,
+                                  ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                  a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                  the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                  Pods.
                                 properties:
                                   name:
                                     description: |-
@@ -6879,6 +7271,16 @@ spec:
                                       will also be deleted. The pod name and resource name, along with a
                                       generated component, will be used to form a unique name for the
                                       ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                      When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                      belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                      Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                      ResourceClaim generated for the PodGroup. All pods in the group that
+                                      define an equivalent PodResourceClaim matching the
+                                      PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                      generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                      owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                      instead of any individual pod.
 
                                       This field is immutable and no changes will be made to the
                                       corresponding ResourceClaim by the control plane after creating the
@@ -7020,6 +7422,32 @@ spec:
                                     Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
+                                seLinuxChangePolicy:
+                                  description: |-
+                                    seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                    It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                    Valid values are "MountOption" and "Recursive".
+
+                                    "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                    This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                    "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                    This requires all Pods that share the same volume to use the same SELinux label.
+                                    It is not possible to share the same volume among privileged and unprivileged Pods.
+                                    Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                    whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                    CSIDriver instance. Other volumes are always re-labelled recursively.
+                                    "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                    If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                    If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                    and "Recursive" for all other volumes.
+
+                                    This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                    All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
                                 seLinuxOptions:
                                   description: |-
                                     The SELinux context to be applied to all containers.
@@ -7206,9 +7634,10 @@ spec:
                                   operator:
                                     description: |-
                                       Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                       Exists is equivalent to wildcard for value, so that a pod can
                                       tolerate all taints of a particular category.
+                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
                                     description: |-
@@ -7352,7 +7781,6 @@ spec:
                                       - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                       If this value is nil, the behavior is equivalent to the Honor policy.
-                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                     type: string
                                   nodeTaintsPolicy:
                                     description: |-
@@ -7363,7 +7791,6 @@ spec:
                                       - Ignore: node taints are ignored. All nodes are included.
 
                                       If this value is nil, the behavior is equivalent to the Ignore policy.
-                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                     type: string
                                   topologyKey:
                                     description: |-
@@ -7421,6 +7848,8 @@ spec:
                                     description: |-
                                       awsElasticBlockStore represents an AWS Disk resource that is attached to a
                                       kubelet's host machine and then exposed to the pod.
+                                      Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                      awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
@@ -7452,8 +7881,10 @@ spec:
                                       - volumeID
                                     type: object
                                   azureDisk:
-                                    description: azureDisk represents an Azure Data
-                                      Disk mount on the host and bind mount to the pod.
+                                    description: |-
+                                      azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                      Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                      are redirected to the disk.csi.azure.com CSI driver.
                                     properties:
                                       cachingMode:
                                         description: "cachingMode is the Host Caching
@@ -7492,9 +7923,10 @@ spec:
                                       - diskURI
                                     type: object
                                   azureFile:
-                                    description: azureFile represents an Azure File
-                                      Service mount on the host and bind mount to the
-                                      pod.
+                                    description: |-
+                                      azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                      Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                      are redirected to the file.csi.azure.com CSI driver.
                                     properties:
                                       readOnly:
                                         description: |-
@@ -7514,8 +7946,9 @@ spec:
                                       - shareName
                                     type: object
                                   cephfs:
-                                    description: cephFS represents a Ceph FS mount on
-                                      the host that shares a pod's lifetime
+                                    description: |-
+                                      cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                      Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                                     properties:
                                       monitors:
                                         description: |-
@@ -7568,6 +8001,8 @@ spec:
                                   cinder:
                                     description: |-
                                       cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                      are redirected to the cinder.csi.openstack.org CSI driver.
                                       More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
@@ -7679,7 +8114,7 @@ spec:
                                   csi:
                                     description: csi (Container Storage Interface) represents
                                       ephemeral storage that is handled by certain external
-                                      CSI drivers (Beta feature).
+                                      CSI drivers.
                                     properties:
                                       driver:
                                         description: |-
@@ -7999,7 +8434,7 @@ spec:
                                               resources:
                                                 description: |-
                                                   resources represents the minimum resources the volume should have.
-                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  Users are allowed to specify resource requirements
                                                   that are lower than previous value but must still be higher than capacity recorded in the
                                                   status field of the claim.
                                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -8088,15 +8523,13 @@ spec:
                                                   volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                                   If specified, the CSI driver will create or update the volume with the attributes defined
                                                   in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                                  it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                                  will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                                  If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                                  will be set by the persistentvolume controller if it exists.
+                                                  it can be changed after the claim is created. An empty string or nil value indicates that no
+                                                  VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                                  this field can be reset to its previous value (including nil) to cancel the modification.
                                                   If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                                   set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                                   exists.
                                                   More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                                  (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                                 type: string
                                               volumeMode:
                                                 description: |-
@@ -8154,6 +8587,7 @@ spec:
                                     description: |-
                                       flexVolume represents a generic volume resource that is
                                       provisioned/attached using an exec based plugin.
+                                      Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
@@ -8199,9 +8633,9 @@ spec:
                                       - driver
                                     type: object
                                   flocker:
-                                    description: flocker represents a Flocker volume
-                                      attached to a kubelet's host machine. This depends
-                                      on the Flocker control service being running
+                                    description: |-
+                                      flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                      Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                                     properties:
                                       datasetName:
                                         description: |-
@@ -8218,6 +8652,8 @@ spec:
                                     description: |-
                                       gcePersistentDisk represents a GCE Disk resource that is attached to a
                                       kubelet's host machine and then exposed to the pod.
+                                      Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                      gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
@@ -8253,7 +8689,7 @@ spec:
                                   gitRepo:
                                     description: |-
                                       gitRepo represents a git repository at a particular revision.
-                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                                       EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                                       into the Pod's container.
                                     properties:
@@ -8277,12 +8713,11 @@ spec:
                                   glusterfs:
                                     description: |-
                                       glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                                      Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                                     properties:
                                       endpoints:
-                                        description: |-
-                                          endpoints is the endpoint name that details Glusterfs topology.
-                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                        description: endpoints is the endpoint name
+                                          that details Glusterfs topology.
                                         type: string
                                       path:
                                         description: |-
@@ -8335,8 +8770,8 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
-                                      Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                      The volume will be mounted read-only (ro).
+                                      Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
                                       pullPolicy:
@@ -8361,7 +8796,7 @@ spec:
                                     description: |-
                                       iscsi represents an ISCSI Disk resource that is attached to a
                                       kubelet's host machine and then exposed to the pod.
-                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -8488,9 +8923,9 @@ spec:
                                       - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: photonPersistentDisk represents a PhotonController
-                                      persistent disk attached and mounted on kubelets
-                                      host machine
+                                    description: |-
+                                      photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                      Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                                     properties:
                                       fsType:
                                         description: |-
@@ -8506,8 +8941,10 @@ spec:
                                       - pdID
                                     type: object
                                   portworxVolume:
-                                    description: portworxVolume represents a portworx
-                                      volume attached and mounted on kubelets host machine
+                                    description: |-
+                                      portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                      Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -8792,6 +9229,129 @@ spec:
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                               type: object
+                                            podCertificate:
+                                              description: |-
+                                                Projects an auto-rotating credential bundle (private key and certificate
+                                                chain) that the pod can use either as a TLS client or server.
+
+                                                Kubelet generates a private key and uses it to send a
+                                                PodCertificateRequest to the named signer.  Once the signer approves the
+                                                request and issues a certificate chain, Kubelet writes the key and
+                                                certificate chain to the pod filesystem.  The pod does not start until
+                                                certificates have been issued for each podCertificate projected volume
+                                                source in its spec.
+
+                                                Kubelet will begin trying to rotate the certificate at the time indicated
+                                                by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                                timestamp.
+
+                                                Kubelet can write a single file, indicated by the credentialBundlePath
+                                                field, or separate files, indicated by the keyPath and
+                                                certificateChainPath fields.
+
+                                                The credential bundle is a single file in PEM format.  The first PEM
+                                                entry is the private key (in PKCS#8 format), and the remaining PEM
+                                                entries are the certificate chain issued by the signer (typically,
+                                                signers will return their certificate chain in leaf-to-root order).
+
+                                                Prefer using the credential bundle format, since your application code
+                                                can read it atomically.  If you use keyPath and certificateChainPath,
+                                                your application must make two separate file reads. If these coincide
+                                                with a certificate rotation, it is possible that the private key and leaf
+                                                certificate you read may not correspond to each other.  Your application
+                                                will need to check for this condition, and re-read until they are
+                                                consistent.
+
+                                                The named signer controls chooses the format of the certificate it
+                                                issues; consult the signer implementation's documentation to learn how to
+                                                use the certificates it issues.
+                                              properties:
+                                                certificateChainPath:
+                                                  description: |-
+                                                    Write the certificate chain at this path in the projected volume.
+
+                                                    Most applications should use credentialBundlePath.  When using keyPath
+                                                    and certificateChainPath, your application needs to check that the key
+                                                    and leaf certificate are consistent, because it is possible to read the
+                                                    files mid-rotation.
+                                                  type: string
+                                                credentialBundlePath:
+                                                  description: |-
+                                                    Write the credential bundle at this path in the projected volume.
+
+                                                    The credential bundle is a single file that contains multiple PEM blocks.
+                                                    The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                    key.
+
+                                                    The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                    certificate chain from the signer (leaf and any intermediates).
+
+                                                    Using credentialBundlePath lets your Pod's application code make a single
+                                                    atomic read that retrieves a consistent key and certificate chain.  If you
+                                                    project them to separate files, your application code will need to
+                                                    additionally check that the leaf certificate was issued to the key.
+                                                  type: string
+                                                keyPath:
+                                                  description: |-
+                                                    Write the key at this path in the projected volume.
+
+                                                    Most applications should use credentialBundlePath.  When using keyPath
+                                                    and certificateChainPath, your application needs to check that the key
+                                                    and leaf certificate are consistent, because it is possible to read the
+                                                    files mid-rotation.
+                                                  type: string
+                                                keyType:
+                                                  description: |-
+                                                    The type of keypair Kubelet will generate for the pod.
+
+                                                    Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                    "ECDSAP521", and "ED25519".
+                                                  type: string
+                                                maxExpirationSeconds:
+                                                  description: |-
+                                                    maxExpirationSeconds is the maximum lifetime permitted for the
+                                                    certificate.
+
+                                                    Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                    generates for this projection.
+
+                                                    If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                    will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                    value is 7862400 (91 days).
+
+                                                    The signer implementation is then free to issue a certificate with any
+                                                    lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                    seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                    `kubernetes.io` signers will never issue certificates with a lifetime
+                                                    longer than 24 hours.
+                                                  format: int32
+                                                  type: integer
+                                                signerName:
+                                                  description: Kubelet's generated CSRs
+                                                    will be addressed to this signer.
+                                                  type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    userAnnotations allow pod authors to pass additional information to
+                                                    the signer implementation.  Kubernetes does not restrict or validate this
+                                                    metadata in any way.
+
+                                                    These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                    the PodCertificateRequest objects that Kubelet creates.
+
+                                                    Entries are subject to the same validation as object metadata annotations,
+                                                    with the addition that all keys must be domain-prefixed. No restrictions
+                                                    are placed on values, except an overall size limitation on the entire field.
+
+                                                    Signers should document the keys and values they support. Signers should
+                                                    deny requests that contain keys they do not recognize.
+                                                  type: object
+                                              required:
+                                                - keyType
+                                                - signerName
+                                              type: object
                                             secret:
                                               description: secret information about
                                                 the secret data to project
@@ -8887,8 +9447,9 @@ spec:
                                         x-kubernetes-list-type: atomic
                                     type: object
                                   quobyte:
-                                    description: quobyte represents a Quobyte mount
-                                      on the host that shares a pod's lifetime
+                                    description: |-
+                                      quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                      Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                                     properties:
                                       group:
                                         description: |-
@@ -8927,7 +9488,7 @@ spec:
                                   rbd:
                                     description: |-
                                       rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md
+                                      Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                                     properties:
                                       fsType:
                                         description: |-
@@ -8999,8 +9560,9 @@ spec:
                                       - monitors
                                     type: object
                                   scaleIO:
-                                    description: scaleIO represents a ScaleIO persistent
-                                      volume attached and mounted on Kubernetes nodes.
+                                    description: |-
+                                      scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                      Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                                     properties:
                                       fsType:
                                         default: xfs
@@ -9134,8 +9696,9 @@ spec:
                                         type: string
                                     type: object
                                   storageos:
-                                    description: storageOS represents a StorageOS volume
-                                      attached and mounted on Kubernetes nodes.
+                                    description: |-
+                                      storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                      Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                                     properties:
                                       fsType:
                                         description: |-
@@ -9180,8 +9743,10 @@ spec:
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: vsphereVolume represents a vSphere
-                                      volume attached and mounted on kubelets host machine
+                                    description: |-
+                                      vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                      Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                      are redirected to the csi.vsphere.vmware.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -9650,7 +10215,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                   Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -9665,7 +10229,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                   Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -9834,7 +10397,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                               Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -9849,7 +10411,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                               Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -9944,8 +10505,8 @@ spec:
                                         most preferred is the one with the greatest sum of weights, i.e.
                                         for each node that meets all of the scheduling requirements (resource
                                         request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                        compute a sum by iterating through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                        compute a sum by iterating through the elements of this field and subtracting
+                                        "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                         node(s) with the highest sum are the most preferred.
                                       items:
                                         description: The weights of all of the matched
@@ -10016,7 +10577,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                   Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -10031,7 +10591,6 @@ spec:
                                                   pod labels will be ignored. The default value is empty.
                                                   The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                   Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                 items:
                                                   type: string
                                                 type: array
@@ -10200,7 +10759,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                               Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -10215,7 +10773,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                               Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -10342,8 +10899,9 @@ spec:
                                       present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
                                         type: string
                                       value:
                                         description: |-
@@ -10400,6 +10958,43 @@ spec:
                                                 type: string
                                             required:
                                               - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                              - volumeName
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
@@ -10469,7 +11064,7 @@ spec:
                                     Cannot be updated.
                                   items:
                                     description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
+                                      of a set of ConfigMaps or Secrets
                                     properties:
                                       configMapRef:
                                         description: The ConfigMap to select from
@@ -10490,8 +11085,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                        description: |-
+                                          Optional text to prepend to the name of each environment variable.
+                                          May consist of any printable ASCII characters except '='.
                                         type: string
                                       secretRef:
                                         description: The Secret to select from
@@ -10541,8 +11137,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to execute
+                                            in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -10557,8 +11153,8 @@ spec:
                                               x-kubernetes-list-type: atomic
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request
-                                            to perform.
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
                                           properties:
                                             host:
                                               description: |-
@@ -10608,9 +11204,8 @@ spec:
                                             - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before being
-                                            terminated.
+                                          description: Sleep represents a duration that
+                                            the container should sleep.
                                           properties:
                                             seconds:
                                               description: Seconds is the number of
@@ -10623,8 +11218,8 @@ spec:
                                         tcpSocket:
                                           description: |-
                                             Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
                                           properties:
                                             host:
                                               description: "Optional: Host name to connect
@@ -10656,8 +11251,8 @@ spec:
                                         More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
+                                          description: Exec specifies a command to execute
+                                            in the container.
                                           properties:
                                             command:
                                               description: |-
@@ -10672,8 +11267,8 @@ spec:
                                               x-kubernetes-list-type: atomic
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request
-                                            to perform.
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
                                           properties:
                                             host:
                                               description: |-
@@ -10723,9 +11318,8 @@ spec:
                                             - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before being
-                                            terminated.
+                                          description: Sleep represents a duration that
+                                            the container should sleep.
                                           properties:
                                             seconds:
                                               description: Seconds is the number of
@@ -10738,8 +11332,8 @@ spec:
                                         tcpSocket:
                                           description: |-
                                             Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
                                           properties:
                                             host:
                                               description: "Optional: Host name to connect
@@ -10758,6 +11352,12 @@ spec:
                                             - port
                                           type: object
                                       type: object
+                                    stopSignal:
+                                      description: |-
+                                        StopSignal defines which signal will be sent to a container when it is being stopped.
+                                        If not specified, the default is defined by the container runtime in use.
+                                        StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                      type: string
                                   type: object
                                 livenessProbe:
                                   description: |-
@@ -10767,7 +11367,8 @@ spec:
                                     More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
+                                      description: Exec specifies a command to execute
+                                        in the container.
                                       properties:
                                         command:
                                           description: |-
@@ -10788,8 +11389,7 @@ spec:
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
                                       properties:
                                         port:
                                           description: Port number of the gRPC service.
@@ -10808,7 +11408,7 @@ spec:
                                         - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
+                                      description: HTTPGet specifies an HTTP GET request
                                         to perform.
                                       properties:
                                         host:
@@ -10876,8 +11476,8 @@ spec:
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
                                       properties:
                                         host:
                                           description: "Optional: Host name to connect
@@ -10976,7 +11576,8 @@ spec:
                                     More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
+                                      description: Exec specifies a command to execute
+                                        in the container.
                                       properties:
                                         command:
                                           description: |-
@@ -10997,8 +11598,7 @@ spec:
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
                                       properties:
                                         port:
                                           description: Port number of the gRPC service.
@@ -11017,7 +11617,7 @@ spec:
                                         - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
+                                      description: HTTPGet specifies an HTTP GET request
                                         to perform.
                                       properties:
                                         host:
@@ -11085,8 +11685,8 @@ spec:
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
                                       properties:
                                         host:
                                           description: "Optional: Host name to connect
@@ -11159,7 +11759,7 @@ spec:
                                         Claims lists the names of resources, defined in spec.resourceClaims,
                                         that are used by this container.
 
-                                        This is an alpha field and requires enabling the
+                                        This field depends on the
                                         DynamicResourceAllocation feature gate.
 
                                         This field is immutable. It can only be set for containers.
@@ -11286,7 +11886,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -11417,7 +12016,8 @@ spec:
                                     More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
+                                      description: Exec specifies a command to execute
+                                        in the container.
                                       properties:
                                         command:
                                           description: |-
@@ -11438,8 +12038,7 @@ spec:
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
                                       properties:
                                         port:
                                           description: Port number of the gRPC service.
@@ -11458,7 +12057,7 @@ spec:
                                         - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
+                                      description: HTTPGet specifies an HTTP GET request
                                         to perform.
                                       properties:
                                         host:
@@ -11526,8 +12125,8 @@ spec:
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
                                       properties:
                                         host:
                                           description: "Optional: Host name to connect
@@ -11743,8 +12342,9 @@ spec:
                                         variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable.
-                                            Must be a C_IDENTIFIER.
+                                          description: |-
+                                            Name of the environment variable.
+                                            May consist of any printable ASCII characters except '='.
                                           type: string
                                         value:
                                           description: |-
@@ -11801,6 +12401,43 @@ spec:
                                                   type: string
                                               required:
                                                 - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              description: |-
+                                                FileKeyRef selects a key of the env file.
+                                                Requires the EnvFiles feature gate to be enabled.
+                                              properties:
+                                                key:
+                                                  description: |-
+                                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  description: |-
+                                                    Specify whether the file or its key must be defined. If the file or key
+                                                    does not exist, then the env var is not published.
+                                                    If optional is set to true and the specified key does not exist,
+                                                    the environment variable will not be set in the Pod's containers.
+
+                                                    If optional is set to false and the specified key does not exist,
+                                                    an error will be returned during Pod creation.
+                                                  type: boolean
+                                                path:
+                                                  description: |-
+                                                    The path within the volume from which to select the file.
+                                                    Must be relative and may not contain the '..' path or start with '..'.
+                                                  type: string
+                                                volumeName:
+                                                  description: The name of the volume
+                                                    mount containing the env file.
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -11866,14 +12503,14 @@ spec:
                                   envFrom:
                                     description: |-
                                       List of sources to populate environment variables in the container.
-                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      When a key exists in multiple
                                       sources, the value associated with the last source will take precedence.
                                       Values defined by an Env with a duplicate key will take precedence.
                                       Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -11894,9 +12531,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be a
-                                            C_IDENTIFIER.
+                                          description: |-
+                                            Optional text to prepend to the name of each environment variable.
+                                            May consist of any printable ASCII characters except '='.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -11947,8 +12584,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
-                                            description: Exec specifies the action to
-                                              take.
+                                            description: Exec specifies a command to
+                                              execute in the container.
                                             properties:
                                               command:
                                                 description: |-
@@ -11963,7 +12600,7 @@ spec:
                                                 x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
+                                            description: HTTPGet specifies an HTTP GET
                                               request to perform.
                                             properties:
                                               host:
@@ -12017,9 +12654,8 @@ spec:
                                               - port
                                             type: object
                                           sleep:
-                                            description: Sleep represents the duration
-                                              that the container should sleep before
-                                              being terminated.
+                                            description: Sleep represents a duration
+                                              that the container should sleep.
                                             properties:
                                               seconds:
                                                 description: Seconds is the number of
@@ -12032,8 +12668,8 @@ spec:
                                           tcpSocket:
                                             description: |-
                                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                              for the backward compatibility. There are no validation of this field and
-                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                              for backward compatibility. There is no validation of this field and
+                                              lifecycle hooks will fail at runtime when it is specified.
                                             properties:
                                               host:
                                                 description: "Optional: Host name to
@@ -12065,8 +12701,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
-                                            description: Exec specifies the action to
-                                              take.
+                                            description: Exec specifies a command to
+                                              execute in the container.
                                             properties:
                                               command:
                                                 description: |-
@@ -12081,7 +12717,7 @@ spec:
                                                 x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
+                                            description: HTTPGet specifies an HTTP GET
                                               request to perform.
                                             properties:
                                               host:
@@ -12135,9 +12771,8 @@ spec:
                                               - port
                                             type: object
                                           sleep:
-                                            description: Sleep represents the duration
-                                              that the container should sleep before
-                                              being terminated.
+                                            description: Sleep represents a duration
+                                              that the container should sleep.
                                             properties:
                                               seconds:
                                                 description: Seconds is the number of
@@ -12150,8 +12785,8 @@ spec:
                                           tcpSocket:
                                             description: |-
                                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                              for the backward compatibility. There are no validation of this field and
-                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                              for backward compatibility. There is no validation of this field and
+                                              lifecycle hooks will fail at runtime when it is specified.
                                             properties:
                                               host:
                                                 description: "Optional: Host name to
@@ -12170,6 +12805,12 @@ spec:
                                               - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        description: |-
+                                          StopSignal defines which signal will be sent to a container when it is being stopped.
+                                          If not specified, the default is defined by the container runtime in use.
+                                          StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     description: |-
@@ -12179,7 +12820,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -12200,8 +12842,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -12220,7 +12861,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -12289,8 +12930,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -12395,7 +13036,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -12416,8 +13058,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -12436,7 +13077,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -12505,8 +13146,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -12547,7 +13188,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -12579,7 +13222,7 @@ spec:
                                           Claims lists the names of resources, defined in spec.resourceClaims,
                                           that are used by this container.
 
-                                          This is an alpha field and requires enabling the
+                                          This field depends on the
                                           DynamicResourceAllocation feature gate.
 
                                           This field is immutable. It can only be set for containers.
@@ -12634,10 +13277,10 @@ spec:
                                   restartPolicy:
                                     description: |-
                                       RestartPolicy defines the restart behavior of individual containers in a pod.
-                                      This field may only be set for init containers, and the only allowed value is "Always".
-                                      For non-init containers or when this field is not specified,
+                                      This overrides the pod-level restart policy. When this field is not specified,
                                       the restart behavior is defined by the Pod's restart policy and the container type.
-                                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                      Additionally, setting the RestartPolicy as "Always" for the init container will
+                                      have the following effect:
                                       this init container will be continually restarted on
                                       exit until all regular containers have terminated. Once all regular
                                       containers have completed, all init containers with restartPolicy "Always"
@@ -12649,6 +13292,59 @@ spec:
                                       init container is started, or after any startupProbe has successfully
                                       completed.
                                     type: string
+                                  restartPolicyRules:
+                                    description: |-
+                                      Represents a list of rules to be checked to determine if the
+                                      container should be restarted on exit. The rules are evaluated in
+                                      order. Once a rule matches a container exit condition, the remaining
+                                      rules are ignored. If no rule matches the container exit condition,
+                                      the Container-level restart policy determines the whether the container
+                                      is restarted or not. Constraints on the rules:
+                                      - At most 20 rules are allowed.
+                                      - Rules can have the same action.
+                                      - Identical rules are not forbidden in validations.
+                                      When rules are specified, container MUST set RestartPolicy explicitly
+                                      even it if matches the Pod's RestartPolicy.
+                                    items:
+                                      description: ContainerRestartRule describes how
+                                        a container exit is handled.
+                                      properties:
+                                        action:
+                                          description: |-
+                                            Specifies the action taken on a container exit if the requirements
+                                            are satisfied. The only possible value is "Restart" to restart the
+                                            container.
+                                          type: string
+                                        exitCodes:
+                                          description: Represents the exit codes to
+                                            check on container exits.
+                                          properties:
+                                            operator:
+                                              description: |-
+                                                Represents the relationship between the container exit code(s) and the
+                                                specified values. Possible values are:
+                                                - In: the requirement is satisfied if the container exit code is in the
+                                                  set of specified values.
+                                                - NotIn: the requirement is satisfied if the container exit code is
+                                                  not in the set of specified values.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                Specifies the set of values to check for container exit codes.
+                                                At most 255 elements are allowed.
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                            - operator
+                                          type: object
+                                      required:
+                                        - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     description: |-
                                       SecurityContext defines the security options the container should be run with.
@@ -12724,7 +13420,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -12855,7 +13550,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -12876,8 +13572,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -12896,7 +13591,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -12965,8 +13660,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -13178,9 +13873,13 @@ spec:
                                       options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
+                                        description: |-
+                                          Name is this DNS resolver option's name.
+                                          Required.
                                         type: string
                                       value:
+                                        description: Value is this DNS resolver option's
+                                          value.
                                         type: string
                                     type: object
                                   type: array
@@ -13343,8 +14042,9 @@ spec:
                                         variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable.
-                                            Must be a C_IDENTIFIER.
+                                          description: |-
+                                            Name of the environment variable.
+                                            May consist of any printable ASCII characters except '='.
                                           type: string
                                         value:
                                           description: |-
@@ -13401,6 +14101,43 @@ spec:
                                                   type: string
                                               required:
                                                 - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              description: |-
+                                                FileKeyRef selects a key of the env file.
+                                                Requires the EnvFiles feature gate to be enabled.
+                                              properties:
+                                                key:
+                                                  description: |-
+                                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  description: |-
+                                                    Specify whether the file or its key must be defined. If the file or key
+                                                    does not exist, then the env var is not published.
+                                                    If optional is set to true and the specified key does not exist,
+                                                    the environment variable will not be set in the Pod's containers.
+
+                                                    If optional is set to false and the specified key does not exist,
+                                                    an error will be returned during Pod creation.
+                                                  type: boolean
+                                                path:
+                                                  description: |-
+                                                    The path within the volume from which to select the file.
+                                                    Must be relative and may not contain the '..' path or start with '..'.
+                                                  type: string
+                                                volumeName:
+                                                  description: The name of the volume
+                                                    mount containing the env file.
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                                - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -13466,14 +14203,14 @@ spec:
                                   envFrom:
                                     description: |-
                                       List of sources to populate environment variables in the container.
-                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      When a key exists in multiple
                                       sources, the value associated with the last source will take precedence.
                                       Values defined by an Env with a duplicate key will take precedence.
                                       Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -13494,9 +14231,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be a
-                                            C_IDENTIFIER.
+                                          description: |-
+                                            Optional text to prepend to the name of each environment variable.
+                                            May consist of any printable ASCII characters except '='.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -13547,8 +14284,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
-                                            description: Exec specifies the action to
-                                              take.
+                                            description: Exec specifies a command to
+                                              execute in the container.
                                             properties:
                                               command:
                                                 description: |-
@@ -13563,7 +14300,7 @@ spec:
                                                 x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
+                                            description: HTTPGet specifies an HTTP GET
                                               request to perform.
                                             properties:
                                               host:
@@ -13617,9 +14354,8 @@ spec:
                                               - port
                                             type: object
                                           sleep:
-                                            description: Sleep represents the duration
-                                              that the container should sleep before
-                                              being terminated.
+                                            description: Sleep represents a duration
+                                              that the container should sleep.
                                             properties:
                                               seconds:
                                                 description: Seconds is the number of
@@ -13632,8 +14368,8 @@ spec:
                                           tcpSocket:
                                             description: |-
                                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                              for the backward compatibility. There are no validation of this field and
-                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                              for backward compatibility. There is no validation of this field and
+                                              lifecycle hooks will fail at runtime when it is specified.
                                             properties:
                                               host:
                                                 description: "Optional: Host name to
@@ -13665,8 +14401,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
-                                            description: Exec specifies the action to
-                                              take.
+                                            description: Exec specifies a command to
+                                              execute in the container.
                                             properties:
                                               command:
                                                 description: |-
@@ -13681,7 +14417,7 @@ spec:
                                                 x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
+                                            description: HTTPGet specifies an HTTP GET
                                               request to perform.
                                             properties:
                                               host:
@@ -13735,9 +14471,8 @@ spec:
                                               - port
                                             type: object
                                           sleep:
-                                            description: Sleep represents the duration
-                                              that the container should sleep before
-                                              being terminated.
+                                            description: Sleep represents a duration
+                                              that the container should sleep.
                                             properties:
                                               seconds:
                                                 description: Seconds is the number of
@@ -13750,8 +14485,8 @@ spec:
                                           tcpSocket:
                                             description: |-
                                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                              for the backward compatibility. There are no validation of this field and
-                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                              for backward compatibility. There is no validation of this field and
+                                              lifecycle hooks will fail at runtime when it is specified.
                                             properties:
                                               host:
                                                 description: "Optional: Host name to
@@ -13770,6 +14505,12 @@ spec:
                                               - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        description: |-
+                                          StopSignal defines which signal will be sent to a container when it is being stopped.
+                                          If not specified, the default is defined by the container runtime in use.
+                                          StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     description: |-
@@ -13779,7 +14520,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -13800,8 +14542,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -13820,7 +14561,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -13889,8 +14630,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -13995,7 +14736,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -14016,8 +14758,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -14036,7 +14777,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -14105,8 +14846,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -14147,7 +14888,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -14179,7 +14922,7 @@ spec:
                                           Claims lists the names of resources, defined in spec.resourceClaims,
                                           that are used by this container.
 
-                                          This is an alpha field and requires enabling the
+                                          This field depends on the
                                           DynamicResourceAllocation feature gate.
 
                                           This field is immutable. It can only be set for containers.
@@ -14234,10 +14977,10 @@ spec:
                                   restartPolicy:
                                     description: |-
                                       RestartPolicy defines the restart behavior of individual containers in a pod.
-                                      This field may only be set for init containers, and the only allowed value is "Always".
-                                      For non-init containers or when this field is not specified,
+                                      This overrides the pod-level restart policy. When this field is not specified,
                                       the restart behavior is defined by the Pod's restart policy and the container type.
-                                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                      Additionally, setting the RestartPolicy as "Always" for the init container will
+                                      have the following effect:
                                       this init container will be continually restarted on
                                       exit until all regular containers have terminated. Once all regular
                                       containers have completed, all init containers with restartPolicy "Always"
@@ -14249,6 +14992,59 @@ spec:
                                       init container is started, or after any startupProbe has successfully
                                       completed.
                                     type: string
+                                  restartPolicyRules:
+                                    description: |-
+                                      Represents a list of rules to be checked to determine if the
+                                      container should be restarted on exit. The rules are evaluated in
+                                      order. Once a rule matches a container exit condition, the remaining
+                                      rules are ignored. If no rule matches the container exit condition,
+                                      the Container-level restart policy determines the whether the container
+                                      is restarted or not. Constraints on the rules:
+                                      - At most 20 rules are allowed.
+                                      - Rules can have the same action.
+                                      - Identical rules are not forbidden in validations.
+                                      When rules are specified, container MUST set RestartPolicy explicitly
+                                      even it if matches the Pod's RestartPolicy.
+                                    items:
+                                      description: ContainerRestartRule describes how
+                                        a container exit is handled.
+                                      properties:
+                                        action:
+                                          description: |-
+                                            Specifies the action taken on a container exit if the requirements
+                                            are satisfied. The only possible value is "Restart" to restart the
+                                            container.
+                                          type: string
+                                        exitCodes:
+                                          description: Represents the exit codes to
+                                            check on container exits.
+                                          properties:
+                                            operator:
+                                              description: |-
+                                                Represents the relationship between the container exit code(s) and the
+                                                specified values. Possible values are:
+                                                - In: the requirement is satisfied if the container exit code is in the
+                                                  set of specified values.
+                                                - NotIn: the requirement is satisfied if the container exit code is
+                                                  not in the set of specified values.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                Specifies the set of values to check for container exit codes.
+                                                At most 255 elements are allowed.
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                            - operator
+                                          type: object
+                                      required:
+                                        - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     description: |-
                                       SecurityContext defines the security options the container should be run with.
@@ -14324,7 +15120,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -14455,7 +15250,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
-                                        description: Exec specifies the action to take.
+                                        description: Exec specifies a command to execute
+                                          in the container.
                                         properties:
                                           command:
                                             description: |-
@@ -14476,8 +15272,7 @@ spec:
                                         format: int32
                                         type: integer
                                       grpc:
-                                        description: GRPC specifies an action involving
-                                          a GRPC port.
+                                        description: GRPC specifies a GRPC HealthCheckRequest.
                                         properties:
                                           port:
                                             description: Port number of the gRPC service.
@@ -14496,7 +15291,7 @@ spec:
                                           - port
                                         type: object
                                       httpGet:
-                                        description: HTTPGet specifies the http request
+                                        description: HTTPGet specifies an HTTP GET request
                                           to perform.
                                         properties:
                                           host:
@@ -14565,8 +15360,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving
-                                          a TCP port.
+                                        description: TCPSocket specifies a connection
+                                          to a TCP port.
                                         properties:
                                           host:
                                             description: "Optional: Host name to connect
@@ -14915,6 +15710,14 @@ spec:
 
                                   It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                   Containers that need access to the ResourceClaim reference it with this name.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                  belongs to a PodGroup, a PodResourceClaim is matched to a
+                                  PodGroupResourceClaim if all of their fields are equal (Name,
+                                  ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                  a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                  the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                  Pods.
                                 properties:
                                   name:
                                     description: |-
@@ -14939,6 +15742,16 @@ spec:
                                       will also be deleted. The pod name and resource name, along with a
                                       generated component, will be used to form a unique name for the
                                       ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                      When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                      belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                      Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                      ResourceClaim generated for the PodGroup. All pods in the group that
+                                      define an equivalent PodResourceClaim matching the
+                                      PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                      generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                      owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                      instead of any individual pod.
 
                                       This field is immutable and no changes will be made to the
                                       corresponding ResourceClaim by the control plane after creating the
@@ -15080,6 +15893,32 @@ spec:
                                     Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
+                                seLinuxChangePolicy:
+                                  description: |-
+                                    seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                    It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                    Valid values are "MountOption" and "Recursive".
+
+                                    "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                    This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                    "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                    This requires all Pods that share the same volume to use the same SELinux label.
+                                    It is not possible to share the same volume among privileged and unprivileged Pods.
+                                    Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                    whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                    CSIDriver instance. Other volumes are always re-labelled recursively.
+                                    "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                    If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                    If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                    and "Recursive" for all other volumes.
+
+                                    This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                    All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
                                 seLinuxOptions:
                                   description: |-
                                     The SELinux context to be applied to all containers.
@@ -15266,9 +16105,10 @@ spec:
                                   operator:
                                     description: |-
                                       Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                       Exists is equivalent to wildcard for value, so that a pod can
                                       tolerate all taints of a particular category.
+                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
                                     description: |-
@@ -15412,7 +16252,6 @@ spec:
                                       - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                       If this value is nil, the behavior is equivalent to the Honor policy.
-                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                     type: string
                                   nodeTaintsPolicy:
                                     description: |-
@@ -15423,7 +16262,6 @@ spec:
                                       - Ignore: node taints are ignored. All nodes are included.
 
                                       If this value is nil, the behavior is equivalent to the Ignore policy.
-                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                     type: string
                                   topologyKey:
                                     description: |-
@@ -15481,6 +16319,8 @@ spec:
                                     description: |-
                                       awsElasticBlockStore represents an AWS Disk resource that is attached to a
                                       kubelet's host machine and then exposed to the pod.
+                                      Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                      awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
@@ -15512,8 +16352,10 @@ spec:
                                       - volumeID
                                     type: object
                                   azureDisk:
-                                    description: azureDisk represents an Azure Data
-                                      Disk mount on the host and bind mount to the pod.
+                                    description: |-
+                                      azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                      Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                      are redirected to the disk.csi.azure.com CSI driver.
                                     properties:
                                       cachingMode:
                                         description: "cachingMode is the Host Caching
@@ -15552,9 +16394,10 @@ spec:
                                       - diskURI
                                     type: object
                                   azureFile:
-                                    description: azureFile represents an Azure File
-                                      Service mount on the host and bind mount to the
-                                      pod.
+                                    description: |-
+                                      azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                      Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                      are redirected to the file.csi.azure.com CSI driver.
                                     properties:
                                       readOnly:
                                         description: |-
@@ -15574,8 +16417,9 @@ spec:
                                       - shareName
                                     type: object
                                   cephfs:
-                                    description: cephFS represents a Ceph FS mount on
-                                      the host that shares a pod's lifetime
+                                    description: |-
+                                      cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                      Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                                     properties:
                                       monitors:
                                         description: |-
@@ -15628,6 +16472,8 @@ spec:
                                   cinder:
                                     description: |-
                                       cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                      are redirected to the cinder.csi.openstack.org CSI driver.
                                       More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
@@ -15739,7 +16585,7 @@ spec:
                                   csi:
                                     description: csi (Container Storage Interface) represents
                                       ephemeral storage that is handled by certain external
-                                      CSI drivers (Beta feature).
+                                      CSI drivers.
                                     properties:
                                       driver:
                                         description: |-
@@ -16059,7 +16905,7 @@ spec:
                                               resources:
                                                 description: |-
                                                   resources represents the minimum resources the volume should have.
-                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  Users are allowed to specify resource requirements
                                                   that are lower than previous value but must still be higher than capacity recorded in the
                                                   status field of the claim.
                                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -16148,15 +16994,13 @@ spec:
                                                   volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                                   If specified, the CSI driver will create or update the volume with the attributes defined
                                                   in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                                  it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                                  will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                                  If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                                  will be set by the persistentvolume controller if it exists.
+                                                  it can be changed after the claim is created. An empty string or nil value indicates that no
+                                                  VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                                  this field can be reset to its previous value (including nil) to cancel the modification.
                                                   If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                                   set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                                   exists.
                                                   More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                                  (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                                 type: string
                                               volumeMode:
                                                 description: |-
@@ -16214,6 +17058,7 @@ spec:
                                     description: |-
                                       flexVolume represents a generic volume resource that is
                                       provisioned/attached using an exec based plugin.
+                                      Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
@@ -16259,9 +17104,9 @@ spec:
                                       - driver
                                     type: object
                                   flocker:
-                                    description: flocker represents a Flocker volume
-                                      attached to a kubelet's host machine. This depends
-                                      on the Flocker control service being running
+                                    description: |-
+                                      flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                      Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                                     properties:
                                       datasetName:
                                         description: |-
@@ -16278,6 +17123,8 @@ spec:
                                     description: |-
                                       gcePersistentDisk represents a GCE Disk resource that is attached to a
                                       kubelet's host machine and then exposed to the pod.
+                                      Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                      gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
@@ -16313,7 +17160,7 @@ spec:
                                   gitRepo:
                                     description: |-
                                       gitRepo represents a git repository at a particular revision.
-                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                                       EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                                       into the Pod's container.
                                     properties:
@@ -16337,12 +17184,11 @@ spec:
                                   glusterfs:
                                     description: |-
                                       glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                                      Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                                     properties:
                                       endpoints:
-                                        description: |-
-                                          endpoints is the endpoint name that details Glusterfs topology.
-                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                        description: endpoints is the endpoint name
+                                          that details Glusterfs topology.
                                         type: string
                                       path:
                                         description: |-
@@ -16395,8 +17241,8 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
-                                      Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                      The volume will be mounted read-only (ro).
+                                      Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
                                       pullPolicy:
@@ -16421,7 +17267,7 @@ spec:
                                     description: |-
                                       iscsi represents an ISCSI Disk resource that is attached to a
                                       kubelet's host machine and then exposed to the pod.
-                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -16548,9 +17394,9 @@ spec:
                                       - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: photonPersistentDisk represents a PhotonController
-                                      persistent disk attached and mounted on kubelets
-                                      host machine
+                                    description: |-
+                                      photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                      Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                                     properties:
                                       fsType:
                                         description: |-
@@ -16566,8 +17412,10 @@ spec:
                                       - pdID
                                     type: object
                                   portworxVolume:
-                                    description: portworxVolume represents a portworx
-                                      volume attached and mounted on kubelets host machine
+                                    description: |-
+                                      portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                      Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -16852,6 +17700,129 @@ spec:
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                               type: object
+                                            podCertificate:
+                                              description: |-
+                                                Projects an auto-rotating credential bundle (private key and certificate
+                                                chain) that the pod can use either as a TLS client or server.
+
+                                                Kubelet generates a private key and uses it to send a
+                                                PodCertificateRequest to the named signer.  Once the signer approves the
+                                                request and issues a certificate chain, Kubelet writes the key and
+                                                certificate chain to the pod filesystem.  The pod does not start until
+                                                certificates have been issued for each podCertificate projected volume
+                                                source in its spec.
+
+                                                Kubelet will begin trying to rotate the certificate at the time indicated
+                                                by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                                timestamp.
+
+                                                Kubelet can write a single file, indicated by the credentialBundlePath
+                                                field, or separate files, indicated by the keyPath and
+                                                certificateChainPath fields.
+
+                                                The credential bundle is a single file in PEM format.  The first PEM
+                                                entry is the private key (in PKCS#8 format), and the remaining PEM
+                                                entries are the certificate chain issued by the signer (typically,
+                                                signers will return their certificate chain in leaf-to-root order).
+
+                                                Prefer using the credential bundle format, since your application code
+                                                can read it atomically.  If you use keyPath and certificateChainPath,
+                                                your application must make two separate file reads. If these coincide
+                                                with a certificate rotation, it is possible that the private key and leaf
+                                                certificate you read may not correspond to each other.  Your application
+                                                will need to check for this condition, and re-read until they are
+                                                consistent.
+
+                                                The named signer controls chooses the format of the certificate it
+                                                issues; consult the signer implementation's documentation to learn how to
+                                                use the certificates it issues.
+                                              properties:
+                                                certificateChainPath:
+                                                  description: |-
+                                                    Write the certificate chain at this path in the projected volume.
+
+                                                    Most applications should use credentialBundlePath.  When using keyPath
+                                                    and certificateChainPath, your application needs to check that the key
+                                                    and leaf certificate are consistent, because it is possible to read the
+                                                    files mid-rotation.
+                                                  type: string
+                                                credentialBundlePath:
+                                                  description: |-
+                                                    Write the credential bundle at this path in the projected volume.
+
+                                                    The credential bundle is a single file that contains multiple PEM blocks.
+                                                    The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                    key.
+
+                                                    The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                    certificate chain from the signer (leaf and any intermediates).
+
+                                                    Using credentialBundlePath lets your Pod's application code make a single
+                                                    atomic read that retrieves a consistent key and certificate chain.  If you
+                                                    project them to separate files, your application code will need to
+                                                    additionally check that the leaf certificate was issued to the key.
+                                                  type: string
+                                                keyPath:
+                                                  description: |-
+                                                    Write the key at this path in the projected volume.
+
+                                                    Most applications should use credentialBundlePath.  When using keyPath
+                                                    and certificateChainPath, your application needs to check that the key
+                                                    and leaf certificate are consistent, because it is possible to read the
+                                                    files mid-rotation.
+                                                  type: string
+                                                keyType:
+                                                  description: |-
+                                                    The type of keypair Kubelet will generate for the pod.
+
+                                                    Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                    "ECDSAP521", and "ED25519".
+                                                  type: string
+                                                maxExpirationSeconds:
+                                                  description: |-
+                                                    maxExpirationSeconds is the maximum lifetime permitted for the
+                                                    certificate.
+
+                                                    Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                    generates for this projection.
+
+                                                    If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                    will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                    value is 7862400 (91 days).
+
+                                                    The signer implementation is then free to issue a certificate with any
+                                                    lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                    seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                    `kubernetes.io` signers will never issue certificates with a lifetime
+                                                    longer than 24 hours.
+                                                  format: int32
+                                                  type: integer
+                                                signerName:
+                                                  description: Kubelet's generated CSRs
+                                                    will be addressed to this signer.
+                                                  type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    userAnnotations allow pod authors to pass additional information to
+                                                    the signer implementation.  Kubernetes does not restrict or validate this
+                                                    metadata in any way.
+
+                                                    These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                    the PodCertificateRequest objects that Kubelet creates.
+
+                                                    Entries are subject to the same validation as object metadata annotations,
+                                                    with the addition that all keys must be domain-prefixed. No restrictions
+                                                    are placed on values, except an overall size limitation on the entire field.
+
+                                                    Signers should document the keys and values they support. Signers should
+                                                    deny requests that contain keys they do not recognize.
+                                                  type: object
+                                              required:
+                                                - keyType
+                                                - signerName
+                                              type: object
                                             secret:
                                               description: secret information about
                                                 the secret data to project
@@ -16947,8 +17918,9 @@ spec:
                                         x-kubernetes-list-type: atomic
                                     type: object
                                   quobyte:
-                                    description: quobyte represents a Quobyte mount
-                                      on the host that shares a pod's lifetime
+                                    description: |-
+                                      quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                      Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                                     properties:
                                       group:
                                         description: |-
@@ -16987,7 +17959,7 @@ spec:
                                   rbd:
                                     description: |-
                                       rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md
+                                      Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                                     properties:
                                       fsType:
                                         description: |-
@@ -17059,8 +18031,9 @@ spec:
                                       - monitors
                                     type: object
                                   scaleIO:
-                                    description: scaleIO represents a ScaleIO persistent
-                                      volume attached and mounted on Kubernetes nodes.
+                                    description: |-
+                                      scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                      Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                                     properties:
                                       fsType:
                                         default: xfs
@@ -17194,8 +18167,9 @@ spec:
                                         type: string
                                     type: object
                                   storageos:
-                                    description: storageOS represents a StorageOS volume
-                                      attached and mounted on Kubernetes nodes.
+                                    description: |-
+                                      storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                      Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                                     properties:
                                       fsType:
                                         description: |-
@@ -17240,8 +18214,10 @@ spec:
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: vsphereVolume represents a vSphere
-                                      volume attached and mounted on kubelets host machine
+                                    description: |-
+                                      vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                      Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                      are redirected to the csi.vsphere.vmware.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -19839,7 +20815,6 @@ spec:
                                           pod labels will be ignored. The default value is empty.
                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -19854,7 +20829,6 @@ spec:
                                           pod labels will be ignored. The default value is empty.
                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -20021,7 +20995,6 @@ spec:
                                       pod labels will be ignored. The default value is empty.
                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                     items:
                                       type: string
                                     type: array
@@ -20036,7 +21009,6 @@ spec:
                                       pod labels will be ignored. The default value is empty.
                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                     items:
                                       type: string
                                     type: array
@@ -20130,8 +21102,8 @@ spec:
                                 most preferred is the one with the greatest sum of weights, i.e.
                                 for each node that meets all of the scheduling requirements (resource
                                 request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and adding
-                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                compute a sum by iterating through the elements of this field and subtracting
+                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                 node(s) with the highest sum are the most preferred.
                               items:
                                 description: The weights of all of the matched WeightedPodAffinityTerm
@@ -20201,7 +21173,6 @@ spec:
                                           pod labels will be ignored. The default value is empty.
                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -20216,7 +21187,6 @@ spec:
                                           pod labels will be ignored. The default value is empty.
                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -20383,7 +21353,6 @@ spec:
                                       pod labels will be ignored. The default value is empty.
                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                     items:
                                       type: string
                                     type: array
@@ -20398,7 +21367,6 @@ spec:
                                       pod labels will be ignored. The default value is empty.
                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                     items:
                                       type: string
                                     type: array
@@ -20524,8 +21492,9 @@ spec:
                               in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -20581,6 +21550,43 @@ spec:
                                         type: string
                                     required:
                                       - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing
+                                          the env file.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                      - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -20647,7 +21653,7 @@ spec:
                             Cannot be updated.
                           items:
                             description: EnvFromSource represents the source of a set
-                              of ConfigMaps
+                              of ConfigMaps or Secrets
                             properties:
                               configMapRef:
                                 description: The ConfigMap to select from
@@ -20668,8 +21674,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: An optional identifier to prepend to each
-                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -20719,7 +21726,8 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                               properties:
                                 exec:
-                                  description: Exec specifies the action to take.
+                                  description: Exec specifies a command to execute in
+                                    the container.
                                   properties:
                                     command:
                                       description: |-
@@ -20734,8 +21742,8 @@ spec:
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 httpGet:
-                                  description: HTTPGet specifies the http request to
-                                    perform.
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
                                   properties:
                                     host:
                                       description: |-
@@ -20784,8 +21792,8 @@ spec:
                                     - port
                                   type: object
                                 sleep:
-                                  description: Sleep represents the duration that the
-                                    container should sleep before being terminated.
+                                  description: Sleep represents a duration that the
+                                    container should sleep.
                                   properties:
                                     seconds:
                                       description: Seconds is the number of seconds
@@ -20798,8 +21806,8 @@ spec:
                                 tcpSocket:
                                   description: |-
                                     Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                    for the backward compatibility. There are no validation of this field and
-                                    lifecycle hooks will fail in runtime when tcp handler is specified.
+                                    for backward compatibility. There is no validation of this field and
+                                    lifecycle hooks will fail at runtime when it is specified.
                                   properties:
                                     host:
                                       description: "Optional: Host name to connect to,
@@ -20831,7 +21839,8 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                               properties:
                                 exec:
-                                  description: Exec specifies the action to take.
+                                  description: Exec specifies a command to execute in
+                                    the container.
                                   properties:
                                     command:
                                       description: |-
@@ -20846,8 +21855,8 @@ spec:
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 httpGet:
-                                  description: HTTPGet specifies the http request to
-                                    perform.
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
                                   properties:
                                     host:
                                       description: |-
@@ -20896,8 +21905,8 @@ spec:
                                     - port
                                   type: object
                                 sleep:
-                                  description: Sleep represents the duration that the
-                                    container should sleep before being terminated.
+                                  description: Sleep represents a duration that the
+                                    container should sleep.
                                   properties:
                                     seconds:
                                       description: Seconds is the number of seconds
@@ -20910,8 +21919,8 @@ spec:
                                 tcpSocket:
                                   description: |-
                                     Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                    for the backward compatibility. There are no validation of this field and
-                                    lifecycle hooks will fail in runtime when tcp handler is specified.
+                                    for backward compatibility. There is no validation of this field and
+                                    lifecycle hooks will fail at runtime when it is specified.
                                   properties:
                                     host:
                                       description: "Optional: Host name to connect to,
@@ -20930,6 +21939,12 @@ spec:
                                     - port
                                   type: object
                               type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
                           type: object
                         livenessProbe:
                           description: |-
@@ -20939,7 +21954,8 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the
+                                container.
                               properties:
                                 command:
                                   description: |-
@@ -20960,8 +21976,7 @@ spec:
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC
-                                port.
+                              description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -20980,7 +21995,8 @@ spec:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
                                   description: |-
@@ -21047,8 +22063,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a
-                                TCP port.
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
                               properties:
                                 host:
                                   description: "Optional: Host name to connect to, defaults
@@ -21147,7 +22163,8 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the
+                                container.
                               properties:
                                 command:
                                   description: |-
@@ -21168,8 +22185,7 @@ spec:
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC
-                                port.
+                              description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -21188,7 +22204,8 @@ spec:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
                                   description: |-
@@ -21255,8 +22272,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a
-                                TCP port.
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
                               properties:
                                 host:
                                   description: "Optional: Host name to connect to, defaults
@@ -21329,7 +22346,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -21455,7 +22472,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -21586,7 +22602,8 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the
+                                container.
                               properties:
                                 command:
                                   description: |-
@@ -21607,8 +22624,7 @@ spec:
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC
-                                port.
+                              description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -21627,7 +22643,8 @@ spec:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
                                   description: |-
@@ -21694,8 +22711,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a
-                                TCP port.
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
                               properties:
                                 host:
                                   description: "Optional: Host name to connect to, defaults
@@ -21910,8 +22927,9 @@ spec:
                                 present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 value:
                                   description: |-
@@ -21967,6 +22985,43 @@ spec:
                                           type: string
                                       required:
                                         - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          default: false
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount
+                                            containing the env file.
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                        - volumeName
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
@@ -22029,14 +23084,14 @@ spec:
                           envFrom:
                             description: |-
                               List of sources to populate environment variables in the container.
-                              The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                              will be reported as an event when the container is starting. When a key exists in multiple
+                              The keys defined within a source may consist of any printable ASCII characters except '='.
+                              When a key exists in multiple
                               sources, the value associated with the last source will take precedence.
                               Values defined by an Env with a duplicate key will take precedence.
                               Cannot be updated.
                             items:
                               description: EnvFromSource represents the source of a
-                                set of ConfigMaps
+                                set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -22057,8 +23112,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: |-
+                                    Optional text to prepend to the name of each environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -22109,7 +23165,8 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                 properties:
                                   exec:
-                                    description: Exec specifies the action to take.
+                                    description: Exec specifies a command to execute
+                                      in the container.
                                     properties:
                                       command:
                                         description: |-
@@ -22124,7 +23181,7 @@ spec:
                                         x-kubernetes-list-type: atomic
                                     type: object
                                   httpGet:
-                                    description: HTTPGet specifies the http request
+                                    description: HTTPGet specifies an HTTP GET request
                                       to perform.
                                     properties:
                                       host:
@@ -22174,8 +23231,8 @@ spec:
                                       - port
                                     type: object
                                   sleep:
-                                    description: Sleep represents the duration that
-                                      the container should sleep before being terminated.
+                                    description: Sleep represents a duration that the
+                                      container should sleep.
                                     properties:
                                       seconds:
                                         description: Seconds is the number of seconds
@@ -22188,8 +23245,8 @@ spec:
                                   tcpSocket:
                                     description: |-
                                       Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                      for the backward compatibility. There are no validation of this field and
-                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                      for backward compatibility. There is no validation of this field and
+                                      lifecycle hooks will fail at runtime when it is specified.
                                     properties:
                                       host:
                                         description: "Optional: Host name to connect
@@ -22221,7 +23278,8 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                 properties:
                                   exec:
-                                    description: Exec specifies the action to take.
+                                    description: Exec specifies a command to execute
+                                      in the container.
                                     properties:
                                       command:
                                         description: |-
@@ -22236,7 +23294,7 @@ spec:
                                         x-kubernetes-list-type: atomic
                                     type: object
                                   httpGet:
-                                    description: HTTPGet specifies the http request
+                                    description: HTTPGet specifies an HTTP GET request
                                       to perform.
                                     properties:
                                       host:
@@ -22286,8 +23344,8 @@ spec:
                                       - port
                                     type: object
                                   sleep:
-                                    description: Sleep represents the duration that
-                                      the container should sleep before being terminated.
+                                    description: Sleep represents a duration that the
+                                      container should sleep.
                                     properties:
                                       seconds:
                                         description: Seconds is the number of seconds
@@ -22300,8 +23358,8 @@ spec:
                                   tcpSocket:
                                     description: |-
                                       Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                      for the backward compatibility. There are no validation of this field and
-                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                      for backward compatibility. There is no validation of this field and
+                                      lifecycle hooks will fail at runtime when it is specified.
                                     properties:
                                       host:
                                         description: "Optional: Host name to connect
@@ -22320,6 +23378,12 @@ spec:
                                       - port
                                     type: object
                                 type: object
+                              stopSignal:
+                                description: |-
+                                  StopSignal defines which signal will be sent to a container when it is being stopped.
+                                  If not specified, the default is defined by the container runtime in use.
+                                  StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                type: string
                             type: object
                           livenessProbe:
                             description: |-
@@ -22329,7 +23393,8 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in
+                                  the container.
                                 properties:
                                   command:
                                     description: |-
@@ -22350,8 +23415,7 @@ spec:
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC
-                                  port.
+                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
                                     description: Port number of the gRPC service. Number
@@ -22370,7 +23434,8 @@ spec:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to
+                                  perform.
                                 properties:
                                   host:
                                     description: |-
@@ -22437,8 +23502,8 @@ spec:
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving
-                                  a TCP port.
+                                description: TCPSocket specifies a connection to a TCP
+                                  port.
                                 properties:
                                   host:
                                     description: "Optional: Host name to connect to,
@@ -22543,7 +23608,8 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in
+                                  the container.
                                 properties:
                                   command:
                                     description: |-
@@ -22564,8 +23630,7 @@ spec:
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC
-                                  port.
+                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
                                     description: Port number of the gRPC service. Number
@@ -22584,7 +23649,8 @@ spec:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to
+                                  perform.
                                 properties:
                                   host:
                                     description: |-
@@ -22651,8 +23717,8 @@ spec:
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving
-                                  a TCP port.
+                                description: TCPSocket specifies a connection to a TCP
+                                  port.
                                 properties:
                                   host:
                                     description: "Optional: Host name to connect to,
@@ -22693,7 +23759,9 @@ spec:
                                 type: integer
                             type: object
                           resizePolicy:
-                            description: Resources resize policy for the container.
+                            description: |-
+                              Resources resize policy for the container.
+                              This field cannot be set on ephemeral containers.
                             items:
                               description: ContainerResizePolicy represents resource
                                 resize policy for the container.
@@ -22725,7 +23793,7 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-                                  This is an alpha field and requires enabling the
+                                  This field depends on the
                                   DynamicResourceAllocation feature gate.
 
                                   This field is immutable. It can only be set for containers.
@@ -22780,10 +23848,10 @@ spec:
                           restartPolicy:
                             description: |-
                               RestartPolicy defines the restart behavior of individual containers in a pod.
-                              This field may only be set for init containers, and the only allowed value is "Always".
-                              For non-init containers or when this field is not specified,
+                              This overrides the pod-level restart policy. When this field is not specified,
                               the restart behavior is defined by the Pod's restart policy and the container type.
-                              Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                              Additionally, setting the RestartPolicy as "Always" for the init container will
+                              have the following effect:
                               this init container will be continually restarted on
                               exit until all regular containers have terminated. Once all regular
                               containers have completed, all init containers with restartPolicy "Always"
@@ -22795,6 +23863,59 @@ spec:
                               init container is started, or after any startupProbe has successfully
                               completed.
                             type: string
+                          restartPolicyRules:
+                            description: |-
+                              Represents a list of rules to be checked to determine if the
+                              container should be restarted on exit. The rules are evaluated in
+                              order. Once a rule matches a container exit condition, the remaining
+                              rules are ignored. If no rule matches the container exit condition,
+                              the Container-level restart policy determines the whether the container
+                              is restarted or not. Constraints on the rules:
+                              - At most 20 rules are allowed.
+                              - Rules can have the same action.
+                              - Identical rules are not forbidden in validations.
+                              When rules are specified, container MUST set RestartPolicy explicitly
+                              even it if matches the Pod's RestartPolicy.
+                            items:
+                              description: ContainerRestartRule describes how a container
+                                exit is handled.
+                              properties:
+                                action:
+                                  description: |-
+                                    Specifies the action taken on a container exit if the requirements
+                                    are satisfied. The only possible value is "Restart" to restart the
+                                    container.
+                                  type: string
+                                exitCodes:
+                                  description: Represents the exit codes to check on
+                                    container exits.
+                                  properties:
+                                    operator:
+                                      description: |-
+                                        Represents the relationship between the container exit code(s) and the
+                                        specified values. Possible values are:
+                                        - In: the requirement is satisfied if the container exit code is in the
+                                          set of specified values.
+                                        - NotIn: the requirement is satisfied if the container exit code is
+                                          not in the set of specified values.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        Specifies the set of values to check for container exit codes.
+                                        At most 255 elements are allowed.
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                    - operator
+                                  type: object
+                              required:
+                                - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
                           securityContext:
                             description: |-
                               SecurityContext defines the security options the container should be run with.
@@ -22870,7 +23991,6 @@ spec:
                                   procMount denotes the type of proc mount to use for the containers.
                                   The default value is Default which uses the container runtime defaults for
                                   readonly paths and masked paths.
-                                  This requires the ProcMountType feature flag to be enabled.
                                   Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               readOnlyRootFilesystem:
@@ -23001,7 +24121,8 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in
+                                  the container.
                                 properties:
                                   command:
                                     description: |-
@@ -23022,8 +24143,7 @@ spec:
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC
-                                  port.
+                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
                                     description: Port number of the gRPC service. Number
@@ -23042,7 +24162,8 @@ spec:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to
+                                  perform.
                                 properties:
                                   host:
                                     description: |-
@@ -23109,8 +24230,8 @@ spec:
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving
-                                  a TCP port.
+                                description: TCPSocket specifies a connection to a TCP
+                                  port.
                                 properties:
                                   host:
                                     description: "Optional: Host name to connect to,
@@ -23327,9 +24448,12 @@ spec:
                               of a pod.
                             properties:
                               name:
-                                description: Required.
+                                description: |-
+                                  Name is this DNS resolver option's name.
+                                  Required.
                                 type: string
                               value:
+                                description: Value is this DNS resolver option's value.
                                 type: string
                             type: object
                           type: array
@@ -23492,8 +24616,9 @@ spec:
                                 present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 value:
                                   description: |-
@@ -23549,6 +24674,43 @@ spec:
                                           type: string
                                       required:
                                         - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          default: false
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount
+                                            containing the env file.
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                        - volumeName
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
@@ -23611,14 +24773,14 @@ spec:
                           envFrom:
                             description: |-
                               List of sources to populate environment variables in the container.
-                              The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                              will be reported as an event when the container is starting. When a key exists in multiple
+                              The keys defined within a source may consist of any printable ASCII characters except '='.
+                              When a key exists in multiple
                               sources, the value associated with the last source will take precedence.
                               Values defined by an Env with a duplicate key will take precedence.
                               Cannot be updated.
                             items:
                               description: EnvFromSource represents the source of a
-                                set of ConfigMaps
+                                set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -23639,8 +24801,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: |-
+                                    Optional text to prepend to the name of each environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -23691,7 +24854,8 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                 properties:
                                   exec:
-                                    description: Exec specifies the action to take.
+                                    description: Exec specifies a command to execute
+                                      in the container.
                                     properties:
                                       command:
                                         description: |-
@@ -23706,7 +24870,7 @@ spec:
                                         x-kubernetes-list-type: atomic
                                     type: object
                                   httpGet:
-                                    description: HTTPGet specifies the http request
+                                    description: HTTPGet specifies an HTTP GET request
                                       to perform.
                                     properties:
                                       host:
@@ -23756,8 +24920,8 @@ spec:
                                       - port
                                     type: object
                                   sleep:
-                                    description: Sleep represents the duration that
-                                      the container should sleep before being terminated.
+                                    description: Sleep represents a duration that the
+                                      container should sleep.
                                     properties:
                                       seconds:
                                         description: Seconds is the number of seconds
@@ -23770,8 +24934,8 @@ spec:
                                   tcpSocket:
                                     description: |-
                                       Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                      for the backward compatibility. There are no validation of this field and
-                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                      for backward compatibility. There is no validation of this field and
+                                      lifecycle hooks will fail at runtime when it is specified.
                                     properties:
                                       host:
                                         description: "Optional: Host name to connect
@@ -23803,7 +24967,8 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                 properties:
                                   exec:
-                                    description: Exec specifies the action to take.
+                                    description: Exec specifies a command to execute
+                                      in the container.
                                     properties:
                                       command:
                                         description: |-
@@ -23818,7 +24983,7 @@ spec:
                                         x-kubernetes-list-type: atomic
                                     type: object
                                   httpGet:
-                                    description: HTTPGet specifies the http request
+                                    description: HTTPGet specifies an HTTP GET request
                                       to perform.
                                     properties:
                                       host:
@@ -23868,8 +25033,8 @@ spec:
                                       - port
                                     type: object
                                   sleep:
-                                    description: Sleep represents the duration that
-                                      the container should sleep before being terminated.
+                                    description: Sleep represents a duration that the
+                                      container should sleep.
                                     properties:
                                       seconds:
                                         description: Seconds is the number of seconds
@@ -23882,8 +25047,8 @@ spec:
                                   tcpSocket:
                                     description: |-
                                       Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                      for the backward compatibility. There are no validation of this field and
-                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                      for backward compatibility. There is no validation of this field and
+                                      lifecycle hooks will fail at runtime when it is specified.
                                     properties:
                                       host:
                                         description: "Optional: Host name to connect
@@ -23902,6 +25067,12 @@ spec:
                                       - port
                                     type: object
                                 type: object
+                              stopSignal:
+                                description: |-
+                                  StopSignal defines which signal will be sent to a container when it is being stopped.
+                                  If not specified, the default is defined by the container runtime in use.
+                                  StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                type: string
                             type: object
                           livenessProbe:
                             description: |-
@@ -23911,7 +25082,8 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in
+                                  the container.
                                 properties:
                                   command:
                                     description: |-
@@ -23932,8 +25104,7 @@ spec:
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC
-                                  port.
+                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
                                     description: Port number of the gRPC service. Number
@@ -23952,7 +25123,8 @@ spec:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to
+                                  perform.
                                 properties:
                                   host:
                                     description: |-
@@ -24019,8 +25191,8 @@ spec:
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving
-                                  a TCP port.
+                                description: TCPSocket specifies a connection to a TCP
+                                  port.
                                 properties:
                                   host:
                                     description: "Optional: Host name to connect to,
@@ -24125,7 +25297,8 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in
+                                  the container.
                                 properties:
                                   command:
                                     description: |-
@@ -24146,8 +25319,7 @@ spec:
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC
-                                  port.
+                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
                                     description: Port number of the gRPC service. Number
@@ -24166,7 +25338,8 @@ spec:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to
+                                  perform.
                                 properties:
                                   host:
                                     description: |-
@@ -24233,8 +25406,8 @@ spec:
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving
-                                  a TCP port.
+                                description: TCPSocket specifies a connection to a TCP
+                                  port.
                                 properties:
                                   host:
                                     description: "Optional: Host name to connect to,
@@ -24275,7 +25448,9 @@ spec:
                                 type: integer
                             type: object
                           resizePolicy:
-                            description: Resources resize policy for the container.
+                            description: |-
+                              Resources resize policy for the container.
+                              This field cannot be set on ephemeral containers.
                             items:
                               description: ContainerResizePolicy represents resource
                                 resize policy for the container.
@@ -24307,7 +25482,7 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-                                  This is an alpha field and requires enabling the
+                                  This field depends on the
                                   DynamicResourceAllocation feature gate.
 
                                   This field is immutable. It can only be set for containers.
@@ -24362,10 +25537,10 @@ spec:
                           restartPolicy:
                             description: |-
                               RestartPolicy defines the restart behavior of individual containers in a pod.
-                              This field may only be set for init containers, and the only allowed value is "Always".
-                              For non-init containers or when this field is not specified,
+                              This overrides the pod-level restart policy. When this field is not specified,
                               the restart behavior is defined by the Pod's restart policy and the container type.
-                              Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                              Additionally, setting the RestartPolicy as "Always" for the init container will
+                              have the following effect:
                               this init container will be continually restarted on
                               exit until all regular containers have terminated. Once all regular
                               containers have completed, all init containers with restartPolicy "Always"
@@ -24377,6 +25552,59 @@ spec:
                               init container is started, or after any startupProbe has successfully
                               completed.
                             type: string
+                          restartPolicyRules:
+                            description: |-
+                              Represents a list of rules to be checked to determine if the
+                              container should be restarted on exit. The rules are evaluated in
+                              order. Once a rule matches a container exit condition, the remaining
+                              rules are ignored. If no rule matches the container exit condition,
+                              the Container-level restart policy determines the whether the container
+                              is restarted or not. Constraints on the rules:
+                              - At most 20 rules are allowed.
+                              - Rules can have the same action.
+                              - Identical rules are not forbidden in validations.
+                              When rules are specified, container MUST set RestartPolicy explicitly
+                              even it if matches the Pod's RestartPolicy.
+                            items:
+                              description: ContainerRestartRule describes how a container
+                                exit is handled.
+                              properties:
+                                action:
+                                  description: |-
+                                    Specifies the action taken on a container exit if the requirements
+                                    are satisfied. The only possible value is "Restart" to restart the
+                                    container.
+                                  type: string
+                                exitCodes:
+                                  description: Represents the exit codes to check on
+                                    container exits.
+                                  properties:
+                                    operator:
+                                      description: |-
+                                        Represents the relationship between the container exit code(s) and the
+                                        specified values. Possible values are:
+                                        - In: the requirement is satisfied if the container exit code is in the
+                                          set of specified values.
+                                        - NotIn: the requirement is satisfied if the container exit code is
+                                          not in the set of specified values.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        Specifies the set of values to check for container exit codes.
+                                        At most 255 elements are allowed.
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                    - operator
+                                  type: object
+                              required:
+                                - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
                           securityContext:
                             description: |-
                               SecurityContext defines the security options the container should be run with.
@@ -24452,7 +25680,6 @@ spec:
                                   procMount denotes the type of proc mount to use for the containers.
                                   The default value is Default which uses the container runtime defaults for
                                   readonly paths and masked paths.
-                                  This requires the ProcMountType feature flag to be enabled.
                                   Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               readOnlyRootFilesystem:
@@ -24583,7 +25810,8 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in
+                                  the container.
                                 properties:
                                   command:
                                     description: |-
@@ -24604,8 +25832,7 @@ spec:
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC
-                                  port.
+                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
                                     description: Port number of the gRPC service. Number
@@ -24624,7 +25851,8 @@ spec:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to
+                                  perform.
                                 properties:
                                   host:
                                     description: |-
@@ -24691,8 +25919,8 @@ spec:
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving
-                                  a TCP port.
+                                description: TCPSocket specifies a connection to a TCP
+                                  port.
                                 properties:
                                   host:
                                     description: "Optional: Host name to connect to,
@@ -25041,6 +26269,14 @@ spec:
 
                           It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                           Containers that need access to the ResourceClaim reference it with this name.
+
+                          When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                          belongs to a PodGroup, a PodResourceClaim is matched to a
+                          PodGroupResourceClaim if all of their fields are equal (Name,
+                          ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                          a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                          the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                          Pods.
                         properties:
                           name:
                             description: |-
@@ -25065,6 +26301,16 @@ spec:
                               will also be deleted. The pod name and resource name, along with a
                               generated component, will be used to form a unique name for the
                               ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                              belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                              Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                              ResourceClaim generated for the PodGroup. All pods in the group that
+                              define an equivalent PodResourceClaim matching the
+                              PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                              generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                              owned by the PodGroup and their lifecycles are tied to the PodGroup
+                              instead of any individual pod.
 
                               This field is immutable and no changes will be made to the
                               corresponding ResourceClaim by the control plane after creating the
@@ -25206,6 +26452,32 @@ spec:
                             Note that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
+                        seLinuxChangePolicy:
+                          description: |-
+                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                            Valid values are "MountOption" and "Recursive".
+
+                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                            This requires all Pods that share the same volume to use the same SELinux label.
+                            It is not possible to share the same volume among privileged and unprivileged Pods.
+                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                            CSIDriver instance. Other volumes are always re-labelled recursively.
+                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                            and "Recursive" for all other volumes.
+
+                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
                         seLinuxOptions:
                           description: |-
                             The SELinux context to be applied to all containers.
@@ -25391,9 +26663,10 @@ spec:
                           operator:
                             description: |-
                               Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                               Exists is equivalent to wildcard for value, so that a pod can
                               tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                             type: string
                           tolerationSeconds:
                             description: |-
@@ -25536,7 +26809,6 @@ spec:
                               - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                               If this value is nil, the behavior is equivalent to the Honor policy.
-                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
                           nodeTaintsPolicy:
                             description: |-
@@ -25547,7 +26819,6 @@ spec:
                               - Ignore: node taints are ignored. All nodes are included.
 
                               If this value is nil, the behavior is equivalent to the Ignore policy.
-                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
                           topologyKey:
                             description: |-
@@ -25605,6 +26876,8 @@ spec:
                             description: |-
                               awsElasticBlockStore represents an AWS Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
+                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             properties:
                               fsType:
@@ -25636,8 +26909,10 @@ spec:
                               - volumeID
                             type: object
                           azureDisk:
-                            description: azureDisk represents an Azure Data Disk mount
-                              on the host and bind mount to the pod.
+                            description: |-
+                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                              are redirected to the disk.csi.azure.com CSI driver.
                             properties:
                               cachingMode:
                                 description: "cachingMode is the Host Caching mode:
@@ -25676,8 +26951,10 @@ spec:
                               - diskURI
                             type: object
                           azureFile:
-                            description: azureFile represents an Azure File Service
-                              mount on the host and bind mount to the pod.
+                            description: |-
+                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                              are redirected to the file.csi.azure.com CSI driver.
                             properties:
                               readOnly:
                                 description: |-
@@ -25696,8 +26973,9 @@ spec:
                               - shareName
                             type: object
                           cephfs:
-                            description: cephFS represents a Ceph FS mount on the host
-                              that shares a pod's lifetime
+                            description: |-
+                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                             properties:
                               monitors:
                                 description: |-
@@ -25749,6 +27027,8 @@ spec:
                           cinder:
                             description: |-
                               cinder represents a cinder volume attached and mounted on kubelets host machine.
+                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                              are redirected to the cinder.csi.openstack.org CSI driver.
                               More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             properties:
                               fsType:
@@ -25860,7 +27140,7 @@ spec:
                           csi:
                             description: csi (Container Storage Interface) represents
                               ephemeral storage that is handled by certain external
-                              CSI drivers (Beta feature).
+                              CSI drivers.
                             properties:
                               driver:
                                 description: |-
@@ -26175,7 +27455,7 @@ spec:
                                       resources:
                                         description: |-
                                           resources represents the minimum resources the volume should have.
-                                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                          Users are allowed to specify resource requirements
                                           that are lower than previous value but must still be higher than capacity recorded in the
                                           status field of the claim.
                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -26263,15 +27543,13 @@ spec:
                                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                           If specified, the CSI driver will create or update the volume with the attributes defined
                                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                          will be set by the persistentvolume controller if it exists.
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
                                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                           exists.
                                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                         type: string
                                       volumeMode:
                                         description: |-
@@ -26327,6 +27605,7 @@ spec:
                             description: |-
                               flexVolume represents a generic volume resource that is
                               provisioned/attached using an exec based plugin.
+                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                             properties:
                               driver:
                                 description: driver is the name of the driver to use
@@ -26372,9 +27651,9 @@ spec:
                               - driver
                             type: object
                           flocker:
-                            description: flocker represents a Flocker volume attached
-                              to a kubelet's host machine. This depends on the Flocker
-                              control service being running
+                            description: |-
+                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                             properties:
                               datasetName:
                                 description: |-
@@ -26390,6 +27669,8 @@ spec:
                             description: |-
                               gcePersistentDisk represents a GCE Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
+                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             properties:
                               fsType:
@@ -26425,7 +27706,7 @@ spec:
                           gitRepo:
                             description: |-
                               gitRepo represents a git repository at a particular revision.
-                              DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                               EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                               into the Pod's container.
                             properties:
@@ -26449,12 +27730,11 @@ spec:
                           glusterfs:
                             description: |-
                               glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                              More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                             properties:
                               endpoints:
-                                description: |-
-                                  endpoints is the endpoint name that details Glusterfs topology.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                description: endpoints is the endpoint name that details
+                                  Glusterfs topology.
                                 type: string
                               path:
                                 description: |-
@@ -26507,8 +27787,8 @@ spec:
                               A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                               The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                               The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                              The volume will be mounted read-only (ro) and non-executable files (noexec).
-                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                              The volume will be mounted read-only (ro).
+                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                               The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                             properties:
                               pullPolicy:
@@ -26533,7 +27813,7 @@ spec:
                             description: |-
                               iscsi represents an ISCSI Disk resource that is attached to a
                               kubelet's host machine and then exposed to the pod.
-                              More info: https://examples.k8s.io/volumes/iscsi/README.md
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                             properties:
                               chapAuthDiscovery:
                                 description: chapAuthDiscovery defines whether support
@@ -26658,9 +27938,9 @@ spec:
                               - claimName
                             type: object
                           photonPersistentDisk:
-                            description: photonPersistentDisk represents a PhotonController
-                              persistent disk attached and mounted on kubelets host
-                              machine
+                            description: |-
+                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -26676,8 +27956,10 @@ spec:
                               - pdID
                             type: object
                           portworxVolume:
-                            description: portworxVolume represents a portworx volume
-                              attached and mounted on kubelets host machine
+                            description: |-
+                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                              are redirected to the pxd.portworx.com CSI driver.
                             properties:
                               fsType:
                                 description: |-
@@ -26952,6 +28234,129 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                       type: object
+                                    podCertificate:
+                                      description: |-
+                                        Projects an auto-rotating credential bundle (private key and certificate
+                                        chain) that the pod can use either as a TLS client or server.
+
+                                        Kubelet generates a private key and uses it to send a
+                                        PodCertificateRequest to the named signer.  Once the signer approves the
+                                        request and issues a certificate chain, Kubelet writes the key and
+                                        certificate chain to the pod filesystem.  The pod does not start until
+                                        certificates have been issued for each podCertificate projected volume
+                                        source in its spec.
+
+                                        Kubelet will begin trying to rotate the certificate at the time indicated
+                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                        timestamp.
+
+                                        Kubelet can write a single file, indicated by the credentialBundlePath
+                                        field, or separate files, indicated by the keyPath and
+                                        certificateChainPath fields.
+
+                                        The credential bundle is a single file in PEM format.  The first PEM
+                                        entry is the private key (in PKCS#8 format), and the remaining PEM
+                                        entries are the certificate chain issued by the signer (typically,
+                                        signers will return their certificate chain in leaf-to-root order).
+
+                                        Prefer using the credential bundle format, since your application code
+                                        can read it atomically.  If you use keyPath and certificateChainPath,
+                                        your application must make two separate file reads. If these coincide
+                                        with a certificate rotation, it is possible that the private key and leaf
+                                        certificate you read may not correspond to each other.  Your application
+                                        will need to check for this condition, and re-read until they are
+                                        consistent.
+
+                                        The named signer controls chooses the format of the certificate it
+                                        issues; consult the signer implementation's documentation to learn how to
+                                        use the certificates it issues.
+                                      properties:
+                                        certificateChainPath:
+                                          description: |-
+                                            Write the certificate chain at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        credentialBundlePath:
+                                          description: |-
+                                            Write the credential bundle at this path in the projected volume.
+
+                                            The credential bundle is a single file that contains multiple PEM blocks.
+                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                            key.
+
+                                            The remaining blocks are CERTIFICATE blocks, containing the issued
+                                            certificate chain from the signer (leaf and any intermediates).
+
+                                            Using credentialBundlePath lets your Pod's application code make a single
+                                            atomic read that retrieves a consistent key and certificate chain.  If you
+                                            project them to separate files, your application code will need to
+                                            additionally check that the leaf certificate was issued to the key.
+                                          type: string
+                                        keyPath:
+                                          description: |-
+                                            Write the key at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        keyType:
+                                          description: |-
+                                            The type of keypair Kubelet will generate for the pod.
+
+                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                            "ECDSAP521", and "ED25519".
+                                          type: string
+                                        maxExpirationSeconds:
+                                          description: |-
+                                            maxExpirationSeconds is the maximum lifetime permitted for the
+                                            certificate.
+
+                                            Kubelet copies this value verbatim into the PodCertificateRequests it
+                                            generates for this projection.
+
+                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                            value is 7862400 (91 days).
+
+                                            The signer implementation is then free to issue a certificate with any
+                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                            `kubernetes.io` signers will never issue certificates with a lifetime
+                                            longer than 24 hours.
+                                          format: int32
+                                          type: integer
+                                        signerName:
+                                          description: Kubelet's generated CSRs will
+                                            be addressed to this signer.
+                                          type: string
+                                        userAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            userAnnotations allow pod authors to pass additional information to
+                                            the signer implementation.  Kubernetes does not restrict or validate this
+                                            metadata in any way.
+
+                                            These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                            the PodCertificateRequest objects that Kubelet creates.
+
+                                            Entries are subject to the same validation as object metadata annotations,
+                                            with the addition that all keys must be domain-prefixed. No restrictions
+                                            are placed on values, except an overall size limitation on the entire field.
+
+                                            Signers should document the keys and values they support. Signers should
+                                            deny requests that contain keys they do not recognize.
+                                          type: object
+                                      required:
+                                        - keyType
+                                        - signerName
+                                      type: object
                                     secret:
                                       description: secret information about the secret
                                         data to project
@@ -27044,8 +28449,9 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           quobyte:
-                            description: quobyte represents a Quobyte mount on the host
-                              that shares a pod's lifetime
+                            description: |-
+                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                             properties:
                               group:
                                 description: |-
@@ -27084,7 +28490,7 @@ spec:
                           rbd:
                             description: |-
                               rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                              More info: https://examples.k8s.io/volumes/rbd/README.md
+                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -27156,8 +28562,9 @@ spec:
                               - monitors
                             type: object
                           scaleIO:
-                            description: scaleIO represents a ScaleIO persistent volume
-                              attached and mounted on Kubernetes nodes.
+                            description: |-
+                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                             properties:
                               fsType:
                                 default: xfs
@@ -27290,8 +28697,9 @@ spec:
                                 type: string
                             type: object
                           storageos:
-                            description: storageOS represents a StorageOS volume attached
-                              and mounted on Kubernetes nodes.
+                            description: |-
+                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                             properties:
                               fsType:
                                 description: |-
@@ -27336,8 +28744,10 @@ spec:
                                 type: string
                             type: object
                           vsphereVolume:
-                            description: vsphereVolume represents a vSphere volume attached
-                              and mounted on kubelets host machine
+                            description: |-
+                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                              are redirected to the csi.vsphere.vmware.com CSI driver.
                             properties:
                               fsType:
                                 description: |-


### PR DESCRIPTION
    - After the bumping of the Kubernetes API to K8s 1.31 → 1.36 some of the generated types changes, and impacts the operataor.yaml
    - Formatting in other yamls also fixed"