### PR TITLE
[SRVLOGIC-1083] Downgrade j2cl-maven-plugin and its dependencies.

### DIFF
--- a/packages/serverless-workflow-diagram-editor/appformer-bom/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/appformer-bom/pom.xml
@@ -59,7 +59,7 @@
 
   <properties>
     <sonar.skip>true</sonar.skip>
-    <version.j2cl.tools>0.6</version.j2cl.tools>
+    <version.j2cl.tools>0.4</version.j2cl.tools>
   </properties>
 
   <distributionManagement>

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
@@ -116,11 +116,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.kie.j2cl.tools.jakarta</groupId>
-      <artifactId>utils</artifactId>
-    </dependency>
-
     <!-- Test scope. -->
     <dependency>
       <groupId>org.assertj</groupId>

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -252,9 +252,8 @@
     <version.org.uberfire.patternfly>7.74.1.Final</version.org.uberfire.patternfly>
 
     <!-- J2CL -->
-    <version.j2cl>v20260527-1</version.j2cl>
-    <version.j2cl.maven.plugin>0.23.8</version.j2cl.maven.plugin>
-    <version.j2cl.tools.jakarta>0.5</version.j2cl.tools.jakarta>
+    <version.j2cl>v20241110-1</version.j2cl>
+    <version.j2cl.maven.plugin>0.23.2</version.j2cl.maven.plugin>
 
     <!-- Test Libraries -->
     <version.io.github.bonigarcia>6.1.0</version.io.github.bonigarcia>
@@ -336,12 +335,6 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
         <version>${version.ch.qos.logback}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.j2cl.tools.jakarta</groupId>
-        <artifactId>utils</artifactId>
-        <version>${version.j2cl.tools.jakarta}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1083

Looks like the update of j2cl-maven-plugin to 0.23.8 requires Java 21. This PR reverts the upgrade. 