### PR TITLE
SRVLOGIC-1126: Platform version bump side effects

### DIFF
--- a/packages/sonataflow-operator/internal/controller/sonataflow_controller_test.go
+++ b/packages/sonataflow-operator/internal/controller/sonataflow_controller_test.go
@@ -21,9 +21,12 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"k8s.io/client-go/rest"
+
+	"github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api/version"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,7 +85,7 @@ func TestSonataFlowControllerAddsFinalizerReplicasAndSelector(t *testing.T) {
 			t.Fatalf("Failed to fetch supposed to exist workflow %v", err)
 		}
 		// status scale selector must have been set.
-		expectedSelector := "app=greeting,app.kubernetes.io/component=serverless-workflow,app.kubernetes.io/instance=greeting,app.kubernetes.io/managed-by=sonataflow-operator,app.kubernetes.io/name=greeting,app.kubernetes.io/version=main,sonataflow.org/workflow-app=greeting,sonataflow.org/workflow-namespace=TestSonataFlowControllerAddsFinalizerReplicasAndSelector/verify_that_workflow_finalizer,_replicas_and_selector_are_early_added_are_if_missing"
+		expectedSelector := fmt.Sprintf("app=greeting,app.kubernetes.io/component=serverless-workflow,app.kubernetes.io/instance=greeting,app.kubernetes.io/managed-by=sonataflow-operator,app.kubernetes.io/name=greeting,app.kubernetes.io/version=%s,sonataflow.org/workflow-app=greeting,sonataflow.org/workflow-namespace=TestSonataFlowControllerAddsFinalizerReplicasAndSelector/verify_that_workflow_finalizer,_replicas_and_selector_are_early_added_are_if_missing", version.GetImageTagVersion())
 		assert.Equal(t, expectedSelector, afterReconcileWorkflow.Status.Selector)
 	})
 }


### PR DESCRIPTION
## Description

<!-- Describe what this PR changes and why. -->

## Related issue

<!-- Link the JIRA ticket or GitHub issue this PR addresses, e.g. https://redhat.atlassian.net/browse/SRVLOGIC-XXXX -->

<!--

You can also trigger various e2e tests PR checks by adding specific trigger phrase in this PR description.

* To trigger operator e2e tests, add phrase "run operator e2e" to this description.
* To trigger all other e2e tests (image and non-image e2e tests), add phrase "run standard e2e" to this description.

If you forgot to add the trigger phrase and you want to run some e2e tests:
* Update the description with appropriate trigger phrase.
* Convert the PR to Draft PR.
* Mark the PR again as Ready for review.

This will restart the PR checks, including those triggered by the trigger phrase in the PR description.

-->
