### PR TITLE
SRVLOGIC-1152 | Fix undefined matrix.partition in full CI workflows

### DIFF
--- a/.github/workflows/ci_build_full.yml
+++ b/.github/workflows/ci_build_full.yml
@@ -44,6 +44,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        # Single-element partition: this workflow does not split the build into
+        # multiple partitions (unlike ci_build.yml, which uses [0, 1]). The value
+        # is kept only so artifact names include a partition index
+        # (e.g. "Linux_0__tests-reports") and stay consistent with ci_build.yml.
+        partition: [0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Support longpaths"

--- a/.github/workflows/ci_build_operator_full.yml
+++ b/.github/workflows/ci_build_operator_full.yml
@@ -46,6 +46,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        # Single-element partition: this workflow does not split the build into
+        # multiple partitions (unlike ci_build.yml, which uses [0, 1]). The value
+        # is kept only so artifact names include a partition index
+        # (e.g. "Linux_0__tests-reports") and stay consistent with ci_build.yml.
+        partition: [0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Support longpaths"


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1152

## Problem

Both `ci_build_full.yml` and `ci_build_operator_full.yml` pass `${{ matrix.partition }}` as `partition_index` to the `upload-ci-reports-and-artifacts` action, but their matrix strategy only defines `os` -- there is no `partition` property. GitHub Actions silently evaluates the undefined reference to an empty string, so uploads succeed but artifact names are malformed (e.g. `Linux___tests-reports` instead of `Linux_0__tests-reports`).

Found by actionlint: `property "partition" is not defined in object type {os: string} [expression]`.
```
~/go/bin/actionlint \
-ignore 'description is required in metadata' \
.github/workflows/ci_build.yml \
.github/workflows/ci_build_full.yml   \
.github/workflows/ci_build_operator_full.yml
```

## Fix

Add a single-element `partition: [0]` to the matrix in both workflows (with a comment noting these workflows are not partitioned, unlike `ci_build.yml`). This makes `matrix.partition` resolve to `0`, produces informative artifact names, and keeps them consistent with `ci_build.yml`.

