### PR TITLE
SRVLOGIC-1151 | Add run-with-retry helper for resilient Go dependency resolution

### DIFF
--- a/packages/dev-deployment-upload-service/package.json
+++ b/packages/dev-deployment-upload-service/package.json
@@ -24,7 +24,7 @@
     "build-all:win32": "pnpm powershell \"cross-env DDUS_VERSION=$(build-env root.version) make build-all\"",
     "build-install-script:dev": "node scripts/generateInstallScript.js --dev",
     "build-install-script:prod": "node scripts/generateInstallScript.js",
-    "install": "go mod tidy",
+    "install": "run-with-retry --then \"go mod tidy\"",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "start": "make start",
     "start-test-servers": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"node scripts/runTestServers.js\"",
@@ -34,6 +34,7 @@
     "test:win32": "echo 'Not supported'"
   },
   "devDependencies": {
+    "@kie-tools-scripts/run-with-retry": "workspace:*",
     "@kie-tools/jest-base": "workspace:*",
     "@kie-tools/root-env": "workspace:*",
     "@types/jest": "^29.5.12",

--- a/packages/image-env-to-json/package.json
+++ b/packages/image-env-to-json/package.json
@@ -25,7 +25,7 @@
     "build:win32": "pnpm setup:env:win32 make build-win",
     "build:win32:amd": "pnpm setup:env:win32 make build-win-amd64",
     "build:win32:arm": "pnpm setup:env:win32 make build-win-arm64",
-    "install": "go mod tidy",
+    "install": "run-with-retry --then \"go mod tidy\"",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "setup:env": "run-script-os",
     "setup:env:darwin:linux": "cross-env IMAGE_ENV_TO_JSON_VERSION=$(build-env imageEnvToJson.version)",
@@ -33,6 +33,7 @@
     "test": "go test ./..."
   },
   "devDependencies": {
+    "@kie-tools-scripts/run-with-retry": "workspace:*",
     "@kie-tools/root-env": "workspace:*",
     "cross-env": "^7.0.3",
     "rimraf": "^3.0.2",

--- a/packages/kn-plugin-workflow/package.json
+++ b/packages/kn-plugin-workflow/package.json
@@ -37,7 +37,7 @@
     "go:test-e2e:quarkus": "rimraf dist-tests-e2e && mkdir dist-tests-e2e && go test -v ./e2e-tests/... -tags e2e_tests -run Quarkus -timeout 20m 2>&1 | tee ./dist-tests-e2e/go-test-output-e2e.txt",
     "go:test-e2e:quarkus:logs": "rimraf dist-tests-e2e && mkdir dist-tests-e2e && go test -v ./e2e-tests/... --tags e2e_tests -run Quarkus -timeout 20m -logs 2>&1 | tee ./dist-tests-e2e/go-test-output-e2e.txt",
     "go:test-e2e:report": "go run github.com/jstemmer/go-junit-report/v2 -set-exit-code -in ./dist-tests-e2e/go-test-output-e2e.txt -out ./dist-tests-e2e/junit-report-it.xml",
-    "install": "go mod tidy",
+    "install": "run-with-retry --then \"go mod tidy\"",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "setup:env": "cross-env QUARKUS_PLATFORM_GROUP_ID=$(build-env knPluginWorkflow.quarkusPlatformGroupId) QUARKUS_VERSION=$(build-env versions.quarkus) PLUGIN_VERSION=$(build-env knPluginWorkflow.version) DEV_MODE_IMAGE_URL=$(build-env knPluginWorkflow.devModeImageUrl) BUILD_IMAGE_URL=$(build-env knPluginWorkflow.builderImage) KOGITO_VERSION=$(build-env versions.kogito)",
     "setup:env:win32": "pnpm powershell \"cross-env QUARKUS_PLATFORM_GROUP_ID=$(build-env knPluginWorkflow.quarkusPlatformGroupId) QUARKUS_VERSION=$(build-env versions.quarkus) DEV_MODE_IMAGE_URL=$(build-env knPluginWorkflow.devModeImageUrl) KOGITO_VERSION=$(build-env versions.kogito) PLUGIN_VERSION=$(build-env knPluginWorkflow.version)\"",
@@ -54,6 +54,7 @@
     "@kie-tools/sonataflow-quarkus-devui": "workspace:*"
   },
   "devDependencies": {
+    "@kie-tools-scripts/run-with-retry": "workspace:*",
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/sonataflow-builder-image": "workspace:*",
     "@kie-tools/sonataflow-devmode-image": "workspace:*",

--- a/packages/sonataflow-operator/package.json
+++ b/packages/sonataflow-operator/package.json
@@ -34,7 +34,7 @@
     "image:catalog:build:darwin:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && run-script-if --bool \"$(build-env containerImages.build)\" --then \"make catalog-build\"",
     "image:catalog:build:win32": "echo 'Build Operator catalog image not supported on Windows'",
     "install": "run-script-os",
-    "install:darwin:linux": "rimraf bin && go work sync && go mod tidy && pnpm controllers:update:cfg && pnpm format",
+    "install:darwin:linux": "rimraf bin && run-with-retry --then \"go work sync\" --then \"go mod tidy\" && pnpm controllers:update:cfg && pnpm format",
     "install:win32": "echo 'Install not supported on Windows'",
     "test": "run-script-os",
     "test:darwin:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"make test\"",
@@ -45,6 +45,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@kie-tools-scripts/run-with-retry": "workspace:*",
     "@kie-tools/kogito-db-migrator-tool-image": "workspace:*",
     "@kie-tools/python-venv": "workspace:*",
     "@kie-tools/root-env": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,7 +401,7 @@ importers:
         version: 17.0.8
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -413,13 +413,13 @@ importers:
         version: 3.9.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -500,7 +500,7 @@ importers:
         version: 7.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -509,7 +509,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       monaco-editor:
         specifier: ^0.39.0
         version: 0.39.0
@@ -530,7 +530,7 @@ importers:
         version: 2.0.3
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -734,6 +734,9 @@ importers:
 
   packages/dev-deployment-upload-service:
     devDependencies:
+      '@kie-tools-scripts/run-with-retry':
+        specifier: workspace:*
+        version: link:../../scripts/run-with-retry
       '@kie-tools/jest-base':
         specifier: workspace:*
         version: link:../jest-base
@@ -748,7 +751,7 @@ importers:
         version: 7.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -760,7 +763,7 @@ importers:
         version: 1.1.6(patch_hash=82e28a047ef68998aa768f2d01885d4c96b061f05645c133026c22738f9a8753)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       wait-on:
         specifier: ^9.0.10
         version: 9.0.10
@@ -833,7 +836,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -860,7 +863,7 @@ importers:
         version: 2.4.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -869,13 +872,13 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -967,7 +970,7 @@ importers:
         version: 17.0.21
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -976,13 +979,13 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1055,7 +1058,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -1067,7 +1070,7 @@ importers:
         version: 4.14.202
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1076,7 +1079,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1085,7 +1088,7 @@ importers:
         version: 1.1.6(patch_hash=82e28a047ef68998aa768f2d01885d4c96b061f05645c133026c22738f9a8753)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1143,7 +1146,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -1176,7 +1179,7 @@ importers:
         version: 11.0.0(webpack@5.104.1(@swc/core@1.3.92))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1185,7 +1188,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       raw-loader:
         specifier: ^4.0.2
         version: 4.0.2(webpack@5.104.1(@swc/core@1.3.92))
@@ -1197,7 +1200,7 @@ importers:
         version: 1.13.1
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1267,7 +1270,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -1297,7 +1300,7 @@ importers:
         version: 11.0.0(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1306,7 +1309,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       raw-loader:
         specifier: ^4.0.2
         version: 4.0.2(webpack@5.104.1)
@@ -1318,7 +1321,7 @@ importers:
         version: 1.13.1
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1413,7 +1416,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -1431,7 +1434,7 @@ importers:
         version: 17.0.8
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1440,13 +1443,13 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1506,6 +1509,9 @@ importers:
 
   packages/image-env-to-json:
     devDependencies:
+      '@kie-tools-scripts/run-with-retry':
+        specifier: workspace:*
+        version: link:../../scripts/run-with-retry
       '@kie-tools/root-env':
         specifier: workspace:*
         version: link:../root-env
@@ -1578,7 +1584,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -1608,7 +1614,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1620,13 +1626,13 @@ importers:
         version: 3.9.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1678,7 +1684,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -1690,7 +1696,7 @@ importers:
         version: 4.14.202
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1699,7 +1705,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1708,7 +1714,7 @@ importers:
         version: 1.1.6(patch_hash=82e28a047ef68998aa768f2d01885d4c96b061f05645c133026c22738f9a8753)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1736,7 +1742,7 @@ importers:
         version: link:../root-env
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
 
   packages/json-yaml-language-service:
     dependencies:
@@ -1791,7 +1797,7 @@ importers:
         version: 3.5.5
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1800,13 +1806,13 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1855,7 +1861,7 @@ importers:
         version: 4.0.5
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -1864,10 +1870,10 @@ importers:
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1907,7 +1913,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -1925,7 +1931,7 @@ importers:
         version: 17.0.21
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1934,13 +1940,13 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2004,7 +2010,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -2019,7 +2025,7 @@ importers:
         version: 2.4.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -2028,13 +2034,13 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2118,6 +2124,9 @@ importers:
         specifier: workspace:*
         version: link:../sonataflow-quarkus-devui
     devDependencies:
+      '@kie-tools-scripts/run-with-retry':
+        specifier: workspace:*
+        version: link:../../scripts/run-with-retry
       '@kie-tools/root-env':
         specifier: workspace:*
         version: link:../root-env
@@ -2245,13 +2254,13 @@ importers:
         version: 5.6.4(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       webpack:
         specifier: ^5.104.1
         version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
@@ -2408,13 +2417,13 @@ importers:
         version: 5.6.4(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       webpack:
         specifier: ^5.104.1
         version: 5.104.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
@@ -3361,7 +3370,7 @@ importers:
         version: 3.2.3(graphql@14.3.1)
       '@graphql-codegen/cli':
         specifier: ^2.16.5
-        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@24.13.3)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
+        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@26.1.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
       '@graphql-codegen/introspection':
         specifier: ^2.2.3
         version: 2.2.3(encoding@0.1.13)(graphql@14.3.1)
@@ -3626,7 +3635,7 @@ importers:
         version: 3.2.3(graphql@14.3.1)
       '@graphql-codegen/cli':
         specifier: ^2.16.5
-        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@24.13.3)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
+        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@26.1.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
       '@graphql-codegen/introspection':
         specifier: ^2.2.3
         version: 2.2.3(encoding@0.1.13)(graphql@14.3.1)
@@ -3964,7 +3973,7 @@ importers:
         version: 3.2.3(graphql@14.3.1)
       '@graphql-codegen/cli':
         specifier: ^2.16.5
-        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@24.13.3)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
+        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@26.1.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
       '@graphql-codegen/introspection':
         specifier: ^2.2.3
         version: 2.2.3(encoding@0.1.13)(graphql@14.3.1)
@@ -4400,7 +4409,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -4433,7 +4442,7 @@ importers:
         version: 8.3.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -4442,13 +4451,13 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -4509,7 +4518,7 @@ importers:
         version: 3.2.3(graphql@14.3.1)
       '@graphql-codegen/cli':
         specifier: ^2.16.5
-        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@24.13.3)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
+        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@26.1.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
       '@graphql-codegen/introspection':
         specifier: ^2.2.3
         version: 2.2.3(encoding@0.1.13)(graphql@14.3.1)
@@ -4548,7 +4557,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -4563,7 +4572,7 @@ importers:
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -4862,7 +4871,7 @@ importers:
         version: 6.2.1
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -4910,7 +4919,7 @@ importers:
         version: 5.6.4(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -4922,7 +4931,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       junit-report-merger:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4946,10 +4955,10 @@ importers:
         version: 2.0.3
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5372,7 +5381,7 @@ importers:
         version: 1.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -5381,7 +5390,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
         version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.104.1)
@@ -5408,7 +5417,7 @@ importers:
         version: 8.0.0(webpack@5.104.1)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5778,19 +5787,19 @@ importers:
         version: 3.5.5
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5875,19 +5884,19 @@ importers:
         version: 1.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5951,19 +5960,19 @@ importers:
         version: 1.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -6068,7 +6077,7 @@ importers:
         version: 5.6.4(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -6077,7 +6086,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       minimatch:
         specifier: 5.1.9
         version: 5.1.9
@@ -6110,7 +6119,7 @@ importers:
         version: 2.0.3
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -6570,7 +6579,7 @@ importers:
         version: 11.0.0(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -6594,7 +6603,7 @@ importers:
         version: 5.3.16(@swc/core@1.3.92)(webpack@5.104.1)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       url:
         specifier: ^0.11.3
         version: 0.11.3
@@ -6648,7 +6657,7 @@ importers:
         version: 14.3.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -6872,7 +6881,7 @@ importers:
         version: 3.2.3(graphql@14.3.1)
       '@graphql-codegen/cli':
         specifier: ^2.16.5
-        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@24.13.3)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
+        version: 2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@26.1.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)
       '@graphql-codegen/introspection':
         specifier: ^2.2.3
         version: 2.2.3(encoding@0.1.13)(graphql@14.3.1)
@@ -6902,7 +6911,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@types/enzyme':
         specifier: ^3.10.13
         version: 3.10.18
@@ -6962,7 +6971,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -6995,13 +7004,13 @@ importers:
         version: 8.0.0(webpack@5.104.1)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@25.5.1(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@25.5.1(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: ^9.4.2
         version: 9.4.2(typescript@5.9.3)(webpack@5.104.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       tsconfig-paths-webpack-plugin:
         specifier: ^3.5.2
         version: 3.5.2
@@ -7029,6 +7038,9 @@ importers:
 
   packages/sonataflow-operator:
     devDependencies:
+      '@kie-tools-scripts/run-with-retry':
+        specifier: workspace:*
+        version: link:../../scripts/run-with-retry
       '@kie-tools/kogito-db-migrator-tool-image':
         specifier: workspace:*
         version: link:../kogito-db-migrator-tool-image
@@ -7126,7 +7138,7 @@ importers:
         version: 5.4.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -7150,7 +7162,7 @@ importers:
         version: 11.0.0(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -7165,10 +7177,10 @@ importers:
         version: 1.13.1
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -7294,19 +7306,19 @@ importers:
         version: 3.5.5
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -7427,7 +7439,7 @@ importers:
         version: 5.4.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -7451,7 +7463,7 @@ importers:
         version: 11.0.0(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -7466,10 +7478,10 @@ importers:
         version: 1.13.1
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -7554,19 +7566,19 @@ importers:
         version: 3.0.5
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -7792,7 +7804,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -7813,7 +7825,7 @@ importers:
         version: 8.3.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -7822,13 +7834,13 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -7873,13 +7885,13 @@ importers:
         version: 8.3.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       jsdom:
         specifier: 22.1.0
         version: 22.1.0
@@ -7888,7 +7900,7 @@ importers:
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -8089,7 +8101,7 @@ importers:
         version: 0.28.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -8098,7 +8110,7 @@ importers:
         version: 16.0.0
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))
+        version: 3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -8107,7 +8119,7 @@ importers:
         version: 3.0.2
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -8570,7 +8582,7 @@ importers:
         version: 7.28.3(@babel/core@7.29.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -8593,6 +8605,25 @@ importers:
       run-script-os:
         specifier: ^1.1.6
         version: 1.1.6(patch_hash=82e28a047ef68998aa768f2d01885d4c96b061f05645c133026c22738f9a8753)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  scripts/run-with-retry:
+    dependencies:
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    devDependencies:
+      '@kie-tools/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/yargs':
+        specifier: ^17.0.35
+        version: 17.0.35
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -23822,7 +23853,7 @@ snapshots:
       graphql: 14.3.1
       tslib: 2.4.1
 
-  '@graphql-codegen/cli@2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@24.13.3)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)':
+  '@graphql-codegen/cli@2.16.5(@babel/core@7.29.7)(@swc/core@1.3.92)(@types/node@26.1.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@14.3.1)(typescript@5.9.3)':
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/template': 7.28.6
@@ -23832,22 +23863,22 @@ snapshots:
       '@graphql-tools/apollo-engine-loader': 7.3.26(encoding@0.1.13)(graphql@14.3.1)
       '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.7)(graphql@14.3.1)
       '@graphql-tools/git-loader': 7.3.0(@babel/core@7.29.7)(graphql@14.3.1)
-      '@graphql-tools/github-loader': 7.3.28(@babel/core@7.29.7)(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/github-loader': 7.3.28(@babel/core@7.29.7)(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)
       '@graphql-tools/graphql-file-loader': 7.5.17(graphql@14.3.1)
       '@graphql-tools/json-file-loader': 7.4.18(graphql@14.3.1)
       '@graphql-tools/load': 7.8.14(graphql@14.3.1)
-      '@graphql-tools/prisma-loader': 7.2.72(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)
-      '@graphql-tools/url-loader': 7.17.18(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/prisma-loader': 7.2.72(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/url-loader': 7.17.18(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
-      '@whatwg-node/fetch': 0.6.9(@types/node@24.13.3)
+      '@whatwg-node/fetch': 0.6.9(@types/node@26.1.1)
       chalk: 4.1.2
       chokidar: 3.6.0
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@24.13.3)(cosmiconfig@7.0.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@26.1.1)(cosmiconfig@7.0.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))(typescript@5.9.3)
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 14.3.1
-      graphql-config: 4.5.0(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)
+      graphql-config: 4.5.0(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)
       inquirer: 8.2.4
       is-glob: 4.0.3
       json-to-pretty-yaml: 1.2.2
@@ -23856,7 +23887,7 @@ snapshots:
       shell-quote: 1.8.4
       string-env-interpolation: 1.0.1
       ts-log: 2.2.5
-      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       tslib: 2.8.1
       yaml: 1.10.3
       yargs: 17.7.2
@@ -24057,7 +24088,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@graphql-tools/executor-http@0.1.10(@types/node@24.13.3)(graphql@14.3.1)':
+  '@graphql-tools/executor-http@0.1.10(@types/node@26.1.1)(graphql@14.3.1)':
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
       '@repeaterjs/repeater': 3.0.4
@@ -24065,7 +24096,7 @@ snapshots:
       dset: 3.1.2
       extract-files: 11.0.0
       graphql: 14.3.1
-      meros: 1.3.0(@types/node@24.13.3)
+      meros: 1.3.0(@types/node@26.1.1)
       tslib: 2.8.1
       value-or-promise: 1.0.12
     transitivePeerDependencies:
@@ -24105,10 +24136,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@graphql-tools/github-loader@7.3.28(@babel/core@7.29.7)(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)':
+  '@graphql-tools/github-loader@7.3.28(@babel/core@7.29.7)(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1(encoding@0.1.13)
-      '@graphql-tools/executor-http': 0.1.10(@types/node@24.13.3)(graphql@14.3.1)
+      '@graphql-tools/executor-http': 0.1.10(@types/node@26.1.1)(graphql@14.3.1)
       '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.7)(graphql@14.3.1)
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
       '@whatwg-node/fetch': 0.8.8
@@ -24191,9 +24222,9 @@ snapshots:
       graphql: 14.3.1
       tslib: 2.8.1
 
-  '@graphql-tools/prisma-loader@7.2.72(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)':
+  '@graphql-tools/prisma-loader@7.2.72(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)':
     dependencies:
-      '@graphql-tools/url-loader': 7.17.18(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/url-loader': 7.17.18(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
       '@types/js-yaml': 4.0.5
       '@types/json-stable-stringify': 1.0.34
@@ -24245,12 +24276,12 @@ snapshots:
       tslib: 2.8.1
       value-or-promise: 1.0.12
 
-  '@graphql-tools/url-loader@7.17.18(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)':
+  '@graphql-tools/url-loader@7.17.18(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1(encoding@0.1.13)
       '@graphql-tools/delegate': 9.0.35(graphql@14.3.1)
       '@graphql-tools/executor-graphql-ws': 0.0.14(graphql@14.3.1)
-      '@graphql-tools/executor-http': 0.1.10(@types/node@24.13.3)(graphql@14.3.1)
+      '@graphql-tools/executor-http': 0.1.10(@types/node@26.1.1)(graphql@14.3.1)
       '@graphql-tools/executor-legacy-ws': 0.0.11(graphql@14.3.1)
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
       '@graphql-tools/wrap': 9.4.2(graphql@14.3.1)
@@ -24402,7 +24433,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))':
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0(node-notifier@8.0.2)
@@ -24416,7 +24447,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.10.11)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.10.11)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -27576,7 +27607,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))':
+  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.28.6
@@ -27589,7 +27620,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
 
   '@testing-library/react-hooks@8.0.1(@types/react@17.0.21)(react-dom@17.0.2(react@17.0.2))(react-test-renderer@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
@@ -28038,7 +28069,6 @@ snapshots:
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
-    optional: true
 
   '@types/nodemailer@7.0.9':
     dependencies:
@@ -28516,10 +28546,10 @@ snapshots:
 
   '@whatwg-node/events@0.0.3': {}
 
-  '@whatwg-node/fetch@0.6.9(@types/node@24.13.3)':
+  '@whatwg-node/fetch@0.6.9(@types/node@26.1.1)':
     dependencies:
       '@peculiar/webcrypto': 1.4.3
-      '@whatwg-node/node-fetch': 0.0.5(@types/node@24.13.3)
+      '@whatwg-node/node-fetch': 0.0.5(@types/node@26.1.1)
       busboy: 1.6.0
       urlpattern-polyfill: 6.0.2
       web-streams-polyfill: 3.2.1
@@ -28534,9 +28564,9 @@ snapshots:
       urlpattern-polyfill: 8.0.2
       web-streams-polyfill: 3.2.1
 
-  '@whatwg-node/node-fetch@0.0.5(@types/node@24.13.3)':
+  '@whatwg-node/node-fetch@0.0.5(@types/node@26.1.1)':
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       '@whatwg-node/events': 0.0.2
       busboy: 1.6.0
       tslib: 2.8.1
@@ -30382,11 +30412,11 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@24.13.3)(cosmiconfig@7.0.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@26.1.1)(cosmiconfig@7.0.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       cosmiconfig: 7.0.1
-      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
       typescript: 5.9.3
 
   cosmiconfig@6.0.0:
@@ -30466,13 +30496,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -32493,13 +32523,13 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-config@4.5.0(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1):
+  graphql-config@4.5.0(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1):
     dependencies:
       '@graphql-tools/graphql-file-loader': 7.5.17(graphql@14.3.1)
       '@graphql-tools/json-file-loader': 7.4.18(graphql@14.3.1)
       '@graphql-tools/load': 7.8.14(graphql@14.3.1)
       '@graphql-tools/merge': 8.4.2(graphql@14.3.1)
-      '@graphql-tools/url-loader': 7.17.18(@types/node@24.13.3)(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/url-loader': 7.17.18(@types/node@26.1.1)(encoding@0.1.13)(graphql@14.3.1)
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
       cosmiconfig: 8.0.0
       graphql: 14.3.1
@@ -33426,16 +33456,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.0.2
-      jest-config: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -33478,7 +33508,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@24.10.11)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@24.10.11)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -33504,12 +33534,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.10.11
-      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -33534,8 +33564,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 24.13.3
-      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)
+      '@types/node': 26.1.1
+      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -33816,9 +33846,9 @@ snapshots:
     dependencies:
       jest: 29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3))
 
-  jest-when@3.6.0(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))):
+  jest-when@3.6.0(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))):
     dependencies:
-      jest: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
 
   jest-worker@25.5.0:
     dependencies:
@@ -33852,12 +33882,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.0.2
-      jest-cli: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -34649,9 +34679,9 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  meros@1.3.0(@types/node@24.13.3):
+  meros@1.3.0(@types/node@26.1.1):
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
 
   message-box@0.2.7:
     dependencies:
@@ -38013,11 +38043,11 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  ts-jest@29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@25.5.1(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@25.5.1(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -38050,11 +38080,11 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.7)
       esbuild: 0.25.12
 
-  ts-jest@29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -38087,11 +38117,11 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.29.7)
 
-  ts-jest@29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.1.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest@29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@24.13.3)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@26.1.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -38147,14 +38177,14 @@ snapshots:
       '@swc/core': 1.3.92
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.13.3)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.3.92)(@types/node@26.1.1)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.15.0
       acorn-walk: 8.2.0
       arg: 4.1.0
@@ -38315,8 +38345,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@8.3.0:
-    optional: true
+  undici-types@8.3.0: {}
 
   undoo@0.5.0:
     dependencies:

--- a/scripts/run-with-retry/LICENSE
+++ b/scripts/run-with-retry/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/scripts/run-with-retry/README.md
+++ b/scripts/run-with-retry/README.md
@@ -1,0 +1,56 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+
+# @kie-tools-scripts/run-with-retry
+
+CLI tool to run a command (or a batch of commands) with bounded retries and
+backoff, so a step survives transient failures such as flaky network access
+during dependency resolution.
+
+It exists because kie-tools CI occasionally fails at bootstrap when a Go
+package's `install` hook runs `go mod tidy` / `go work sync` and the online
+checksum verification against `sum.golang.org` hits a transient network error,
+which aborts the whole job. Wrapping the resolving step in `run-with-retry`
+makes a transient blip retry instead of killing the job, while genuine breakage
+still surfaces after the attempts are exhausted (the original exit code is
+propagated).
+
+## Usage
+
+```
+run-with-retry [--retries 5] [--delays "5,15,30,60"] [--silent] --then "<command>" [--then "<command>" ...]
+```
+
+- `--then` (required, repeatable): command(s) to run in order, retried together
+  as a batch. If any fails, the whole batch is retried from the start.
+- `--retries` (default `5`): maximum number of attempts.
+- `--delays` (default `"5,15,30,60"`): comma-separated backoff delays in seconds,
+  applied **between** attempts (never after the last one). The last value
+  repeats, so raising `--retries` needs no other change.
+- `--silent`: hide `[run-with-retry]` info logs (command output still shows).
+
+### Example
+
+```
+run-with-retry --then "go work sync" --then "go mod tidy"
+```
+
+With the defaults this runs the two commands, and on failure retries the batch
+with backoff 5s, 15s, 30s, 60s between the 5 attempts, then exits with the
+original error code if still failing.

--- a/scripts/run-with-retry/bin.js
+++ b/scripts/run-with-retry/bin.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+require("./dist/bin");

--- a/scripts/run-with-retry/package.json
+++ b/scripts/run-with-retry/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@kie-tools-scripts/run-with-retry",
+  "version": "0.0.0",
+  "description": "CLI tool to run a command (or a batch of commands) with bounded retries and backoff, to survive transient failures such as flaky network access during dependency resolution",
+  "license": "Apache-2.0",
+  "keywords": [],
+  "homepage": "https://github.com/apache/incubator-kie-tools",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apache/incubator-kie-tools.git"
+  },
+  "bugs": {
+    "url": "https://github.com/apache/incubator-kie-tools/issues"
+  },
+  "bin": {
+    "run-with-retry": "bin.js"
+  },
+  "files": [
+    "bin.js",
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "install": "rimraf dist && tsc"
+  },
+  "dependencies": {
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@kie-tools/tsconfig": "workspace:*",
+    "@types/yargs": "^17.0.35",
+    "rimraf": "^3.0.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/scripts/run-with-retry/src/bin.ts
+++ b/scripts/run-with-retry/src/bin.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { spawn } from "child_process";
+
+function log(isSilent: boolean, ...args: any[]) {
+  if (!isSilent) {
+    console.info(`[run-with-retry]`, ...args);
+  }
+}
+
+// pnpm/Yarn/NPM default to CMD on Windows, which is not ideal for the
+// Command Substitution syntax used across kie-tools scripts. Force PowerShell,
+// mirroring what @kie-tools-scripts/run-script-if does.
+function shell() {
+  return process.platform === "win32" ? { shell: "powershell.exe" } : {};
+}
+
+// Runs a single command string. Resolves on exit code 0, rejects with { code }
+// otherwise. The command's own stdout/stderr are inherited so the original
+// error is always visible to the caller.
+function runCommand(commandString: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const parts = commandString.split(" ").filter((arg) => arg.trim().length > 0);
+    const bin = parts[0];
+    const args = parts.slice(1);
+    const child = spawn(bin, args, { stdio: "inherit", ...shell() });
+    child.on("error", () => reject({ code: 1 }));
+    child.on("exit", (code) => (code === 0 ? resolve() : reject({ code: code ?? 1 })));
+  });
+}
+
+// Runs all commands in order. Rejects as soon as one of them fails.
+async function runBatch(commandStrings: string[]): Promise<void> {
+  for (const commandString of commandStrings) {
+    await runCommand(commandString);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  const argv = yargs(hideBin(process.argv))
+    .epilog(
+      `
+CLI tool to run a command (or a batch of commands) with bounded retries and
+backoff. Useful for steps that can fail transiently, e.g. resolving Go modules
+against sum.golang.org during 'go mod tidy'.
+
+The commands passed to --then are run in order, as a batch. If any of them
+fails, the whole batch is retried from the start after a backoff delay. After
+the last attempt the process exits with the failing command's original exit
+code, so genuine (non-transient) breakage is NOT masked.
+
+Delays are given in seconds between attempts (never after the last attempt).
+The last delay value repeats, so raising --retries needs no other change.
+
+Example:
+$ run-with-retry --retries 5 --delays "5,15,30,60" --then "go work sync" --then "go mod tidy"
+    `
+    )
+    .strict()
+    .options({
+      then: {
+        array: true,
+        required: true,
+        type: "string",
+        description: "Command(s) to run in order. Retried together as a batch.",
+      },
+      retries: {
+        default: 5,
+        type: "number",
+        description: "Maximum number of attempts before failing.",
+      },
+      delays: {
+        default: "5,15,30,60",
+        type: "string",
+        description: "Comma-separated backoff delays in seconds, applied between attempts. The last value repeats.",
+      },
+      silent: {
+        default: false,
+        type: "boolean",
+        description: "Hide [run-with-retry] info logs. Logs from the commands themselves still show.",
+      },
+    })
+    .parseSync();
+
+  const commandStrings = argv.then;
+  const maxAttempts = Math.max(1, Math.floor(argv.retries));
+
+  const delaysSec = argv.delays
+    .split(",")
+    .map((d) => Number(d.trim()))
+    .filter((d) => Number.isFinite(d) && d >= 0);
+  if (delaysSec.length === 0) {
+    delaysSec.push(0);
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      log(argv.silent, `Attempt ${attempt}/${maxAttempts}: ${commandStrings.map((c) => `'${c}'`).join(" && ")}`);
+      await runBatch(commandStrings);
+      log(argv.silent, `Succeeded on attempt ${attempt}/${maxAttempts}.`);
+      return;
+    } catch (e: any) {
+      const code = e && typeof e.code === "number" ? e.code : 1;
+      if (attempt >= maxAttempts) {
+        log(argv.silent, `Failed after ${maxAttempts} attempt(s). Exiting with code ${code}.`);
+        process.exit(code); // original error already printed via inherited stdio
+      }
+      const waitSec = delaysSec[Math.min(attempt - 1, delaysSec.length - 1)];
+      log(argv.silent, `Attempt ${attempt} failed (code ${code}). Retrying in ${waitSec}s...`);
+      await sleep(waitSec * 1000);
+    }
+  }
+}
+
+main().catch((e) => {
+  process.exit(e && typeof e.code === "number" ? e.code : 1);
+});

--- a/scripts/run-with-retry/tsconfig.json
+++ b/scripts/run-with-retry/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@kie-tools/tsconfig/tsconfig.cjs.json"
+}


### PR DESCRIPTION
**ticket**: https://redhat.atlassian.net/browse/SRVLOGIC-1151

CI bootstrap occasionally aborts when Go dependency resolution (go work sync / go mod tidy) hits a transient network failure, e.g. checksum verification against sum.golang.org. The newly introduced package wraps the resolution step in the install hooks with a bounded retry+backoff wrapper so a transient outage no longer kills the whole job immediately but it enables several retries.

New package `@kie-tools-scripts/run-with-retry` ensures 5 attempts with backoff 5/15/30/60s between attempts (last value repeats, so raising `--retries` keeps spacing later attempts by a minute). On exhaustion it exits with the original exit code, so non-transient failures still surface and are not masked.