### PR TITLE
SRVLOGIC-1153 [DON-NOT-MERGE] Reproduce #462 Quarkus SP2 artifact-resolution failure (image e2e)

### DIFF
--- a/.github/workflows/ci_build_image_e2e_tests.yml
+++ b/.github/workflows/ci_build_image_e2e_tests.yml
@@ -92,7 +92,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
+          DEPS_BRANCHNAME: 9.106.x-prod
           PNPM_FILTER: "-F ${{ matrix.package.pnpmName }}..."
 
       - name: Modify pom.xml of sonataflow-quarkus-devui

--- a/.github/workflows/ci_build_image_e2e_tests.yml
+++ b/.github/workflows/ci_build_image_e2e_tests.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
-  KOGITO_RUNTIME_version: "111-SNAPSHOT"
+  KOGITO_RUNTIME_version: "9.106.0"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   MAVEN_REPO_TOKEN: ${{ github.token }}
 
@@ -92,7 +92,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || 'main' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
           PNPM_FILTER: "-F ${{ matrix.package.pnpmName }}..."
 
       - name: Modify pom.xml of sonataflow-quarkus-devui


### PR DESCRIPTION
Temporary reproduction PR (do not merge). Purpose: trigger the image e2e matrix on a `9.106.x-prod`-based PR and capture the exact artifact-resolution failure introduced by #462 (SRVLOGIC-1158).

## Context

#462 set the Quarkus values in `.github/supporting-files/ci/osl/.env` to the productized platform-only Service Pack label:

```
QUARKUS_PLATFORM_version=3.33.2.SP2-redhat-00002
QUARKUS_VERSION=3.33.2.SP2-redhat-00002
KOGITO_IMAGES_CEKIT_MODULES__quarkusGroupId=com.redhat.quarkus.platform
```

`QUARKUS_VERSION` drives `io.quarkus:*` extension coordinates, but the `SP2-redhat-*` label exists only in the `com.redhat.quarkus.platform` namespace, never in `io.quarkus`. The builder image hardcodes `io.quarkus:quarkus-jdbc-postgresql:${QUARKUS_PLATFORM_VERSION}`, so `quarkus-maven-plugin:go-offline` cannot resolve that artifact and fails; the devmode image fails its behave check for the same reason.


## Expected result

`run (sonataflow-builder-image)` and `run (sonataflow-devmode-image)` fail with a Quarkus artifact-resolution error for `io.quarkus:quarkus-jdbc-postgresql:...:3.33.2.SP2-redhat-00002`.

run standard e2e
