### PR TITLE
SRVLOGIC-1153 | Fix CI dependency resolution on 9.106.x-prod (kogito version + branch fallback)

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -45,6 +45,38 @@ runs:
         cd ${{ inputs.working_dir }}
         df -h .
 
+    # Disabled: local maven cache for coordinated cross-repository PRs.
+    #
+    # Purpose: when a single change spans kie-tools and its upstream deps
+    # (drools / kogito-runtimes / kogito-apps), this step builds those deps
+    # from the PR author's own forks, using the PR head branch name, so the
+    # kie-tools PR is validated against the matching in-progress upstream
+    # change instead of the default kiegroup branch.
+    #
+    # Why it is disabled here:
+    #   - This composite action is currently used only by osl_sync_main.yml,
+    #     whose triggers are `schedule` and `workflow_dispatch` only (never
+    #     `pull_request`), so `if: github.event_name == 'pull_request'` can
+    #     never be true and the step is unreachable.
+    #   - The owner forks it points at (kubesmarts/{drools,kogito-runtimes,
+    #     kogito-apps}) do not exist, so setup-maven-cache would only fall
+    #     back to kiegroup and produce the same result as the non-PR step
+    #     below.
+    #
+    # Kept as a template: re-enable this block (and point the *_REPO_URL
+    # inputs at real forks) if a `pull_request`-triggered workflow ever
+    # consumes this action.
+    #
+    # - name: Setup local maven cache for PR
+    #   id: setup_maven_cache_pr
+    #   if: "github.event_name == 'pull_request'"
+    #   uses: ./.github/actions/setup-maven-cache
+    #   with:
+    #     DEPS_BRANCHNAME: ${{ github.head_ref }}
+    #     DROOLS_REPO_URL: "https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/drools"
+    #     KOGITO_RUNTIMES_REPO_URL: "https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/kogito-runtimes"
+    #     KOGITO_APPS_REPO_URL: "https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/kogito-apps"
+
     - name: Setup local maven cache for non-pull request runs
       id: setup_maven_cache_non_pr
       if: "github.event_name != 'pull_request'"

--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -45,16 +45,6 @@ runs:
         cd ${{ inputs.working_dir }}
         df -h .
 
-    - name: Setup local maven cache for PR
-      id: setup_maven_cache_pr
-      if: "github.event_name == 'pull_request'"
-      uses: ./.github/actions/setup-maven-cache
-      with:
-        DEPS_BRANCHNAME: ${{ github.head_ref }}
-        DROOLS_REPO_URL: "https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/drools"
-        KOGITO_RUNTIMES_REPO_URL: "https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/kogito-runtimes"
-        KOGITO_APPS_REPO_URL: "https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/kogito-apps"
-
     - name: Setup local maven cache for non-pull request runs
       id: setup_maven_cache_non_pr
       if: "github.event_name != 'pull_request'"

--- a/.github/actions/setup-kie-tools/action.yml
+++ b/.github/actions/setup-kie-tools/action.yml
@@ -51,7 +51,7 @@ runs:
     - name: Setup local maven cache
       if: inputs.USE_REMOTE_ARTIFACTS == 'false'
       id: setup_maven_cache
-      uses: kubesmarts/kie-tools/.github/actions/setup-maven-cache@main
+      uses: ./.github/actions/setup-maven-cache
       with:
         DEPS_BRANCHNAME: ${{ inputs.DEPS_BRANCHNAME }}
         WORKING_DIR: ${{ inputs.WORKING_DIR }}

--- a/.github/actions/setup-maven-cache/action.yml
+++ b/.github/actions/setup-maven-cache/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Branch to use for kiegroup repositories"
     required: false
     default: "9.106.x-prod"
+  FALLBACK_BRANCHNAME:
+    description: "Branch to use when DEPS_BRANCHNAME is not found in a kiegroup repository (per stream; on main set this to main)"
+    required: false
+    default: "9.106.x-prod"
   WORKING_DIR:
     description: "Working directory"
     required: false
@@ -65,24 +69,24 @@ runs:
         # Get Kiegroup Drools Git Ref
         DROOLS_GIT_REF=$(git ls-remote "${{ inputs.DROOLS_REPO_URL }}" refs/heads/${{ inputs.DEPS_BRANCHNAME }} 2>/dev/null | awk '{print $1}' || true)
         if [ -z "$DROOLS_GIT_REF" ]; then
-          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.DROOLS_REPO_URL }}, falling back to kiegroup/drools main branch"
-          DROOLS_GIT_REF=$(git ls-remote "https://github.com/kiegroup/drools" refs/heads/main | awk '{print $1}')
+          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.DROOLS_REPO_URL }}, falling back to kiegroup/drools ${{ inputs.FALLBACK_BRANCHNAME }} branch"
+          DROOLS_GIT_REF=$(git ls-remote "https://github.com/kiegroup/drools" refs/heads/${{ inputs.FALLBACK_BRANCHNAME }} | awk '{print $1}')
         fi
         echo "DROOLS_AND_KOGITO__droolsRepoGitRef=$DROOLS_GIT_REF" >> "$GITHUB_OUTPUT"
 
         # Get Kiegroup Runtimes Git Ref
         RUNTIMES_GIT_REF=$(git ls-remote "${{ inputs.KOGITO_RUNTIMES_REPO_URL }}" refs/heads/${{ inputs.DEPS_BRANCHNAME }} 2>/dev/null | awk '{print $1}' || true)
         if [ -z "$RUNTIMES_GIT_REF" ]; then
-          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.KOGITO_RUNTIMES_REPO_URL }}, falling back to kiegroup/kogito-runtimes main branch"
-          RUNTIMES_GIT_REF=$(git ls-remote "https://github.com/kiegroup/kogito-runtimes" refs/heads/main | awk '{print $1}')
+          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.KOGITO_RUNTIMES_REPO_URL }}, falling back to kiegroup/kogito-runtimes ${{ inputs.FALLBACK_BRANCHNAME }} branch"
+          RUNTIMES_GIT_REF=$(git ls-remote "https://github.com/kiegroup/kogito-runtimes" refs/heads/${{ inputs.FALLBACK_BRANCHNAME }} | awk '{print $1}')
         fi
         echo "DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef=$RUNTIMES_GIT_REF" >> "$GITHUB_OUTPUT"
 
         # Get Kiegroup Apps Git Ref
         APPS_GIT_REF=$(git ls-remote "${{ inputs.KOGITO_APPS_REPO_URL }}" refs/heads/${{ inputs.DEPS_BRANCHNAME }} 2>/dev/null | awk '{print $1}' || true)
         if [ -z "$APPS_GIT_REF" ]; then
-          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.KOGITO_APPS_REPO_URL }}, falling back to kiegroup/kogito-apps main branch"
-          APPS_GIT_REF=$(git ls-remote "https://github.com/kiegroup/kogito-apps" refs/heads/main | awk '{print $1}')
+          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.KOGITO_APPS_REPO_URL }}, falling back to kiegroup/kogito-apps ${{ inputs.FALLBACK_BRANCHNAME }} branch"
+          APPS_GIT_REF=$(git ls-remote "https://github.com/kiegroup/kogito-apps" refs/heads/${{ inputs.FALLBACK_BRANCHNAME }} | awk '{print $1}')
         fi
         echo "DROOLS_AND_KOGITO__kogitoAppsRepoGitRef=$APPS_GIT_REF" >> "$GITHUB_OUTPUT"
 
@@ -107,9 +111,9 @@ runs:
         # Check if branch exists in the specified repository
         DROOLS_BRANCH_CHECK=$(git ls-remote "${{ inputs.DROOLS_REPO_URL }}" refs/heads/${{ inputs.DEPS_BRANCHNAME }} 2>/dev/null | awk '{print $1}' || true)
         if [ -z "$DROOLS_BRANCH_CHECK" ]; then
-          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.DROOLS_REPO_URL }}, using kiegroup/drools main branch"
+          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.DROOLS_REPO_URL }}, using kiegroup/drools ${{ inputs.FALLBACK_BRANCHNAME }} branch"
           DROOLS_REPO_URL="https://github.com/kiegroup/drools"
-          DROOLS_BRANCH="main"
+          DROOLS_BRANCH="${{ inputs.FALLBACK_BRANCHNAME }}"
         else
           DROOLS_REPO_URL="${{ inputs.DROOLS_REPO_URL }}"
           DROOLS_BRANCH="${{ inputs.DEPS_BRANCHNAME }}"
@@ -126,9 +130,9 @@ runs:
         # Check if branch exists in the specified repository
         RUNTIMES_BRANCH_CHECK=$(git ls-remote "${{ inputs.KOGITO_RUNTIMES_REPO_URL }}" refs/heads/${{ inputs.DEPS_BRANCHNAME }} 2>/dev/null | awk '{print $1}' || true)
         if [ -z "$RUNTIMES_BRANCH_CHECK" ]; then
-          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.KOGITO_RUNTIMES_REPO_URL }}, using kiegroup/kogito-runtimes main branch"
+          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.KOGITO_RUNTIMES_REPO_URL }}, using kiegroup/kogito-runtimes ${{ inputs.FALLBACK_BRANCHNAME }} branch"
           RUNTIMES_REPO_URL="https://github.com/kiegroup/kogito-runtimes"
-          RUNTIMES_BRANCH="main"
+          RUNTIMES_BRANCH="${{ inputs.FALLBACK_BRANCHNAME }}"
         else
           RUNTIMES_REPO_URL="${{ inputs.KOGITO_RUNTIMES_REPO_URL }}"
           RUNTIMES_BRANCH="${{ inputs.DEPS_BRANCHNAME }}"
@@ -145,9 +149,9 @@ runs:
         # Check if branch exists in the specified repository
         APPS_BRANCH_CHECK=$(git ls-remote "${{ inputs.KOGITO_APPS_REPO_URL }}" refs/heads/${{ inputs.DEPS_BRANCHNAME }} 2>/dev/null | awk '{print $1}' || true)
         if [ -z "$APPS_BRANCH_CHECK" ]; then
-          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.KOGITO_APPS_REPO_URL }}, using kiegroup/kogito-apps main branch"
+          echo "::warning::Branch ${{ inputs.DEPS_BRANCHNAME }} not found in ${{ inputs.KOGITO_APPS_REPO_URL }}, using kiegroup/kogito-apps ${{ inputs.FALLBACK_BRANCHNAME }} branch"
           APPS_REPO_URL="https://github.com/kiegroup/kogito-apps"
-          APPS_BRANCH="main"
+          APPS_BRANCH="${{ inputs.FALLBACK_BRANCHNAME }}"
         else
           APPS_REPO_URL="${{ inputs.KOGITO_APPS_REPO_URL }}"
           APPS_BRANCH="${{ inputs.DEPS_BRANCHNAME }}"

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -101,7 +101,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || 'main' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
           PNPM_FILTER: ${{ steps.setup_build_mode.outputs.bootstrapPnpmFilterString }}
       - name: Modify pom.xml of sonataflow-quarkus-devui
         run: python .github/supporting-files/ci/osl/pom-manipulation/inject-fmp-executions.py

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -29,6 +29,7 @@ env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
   KOGITO_RUNTIME_version: "9.106.0"
+  KOGITO_RUNTIME_branch: "9.106.x-prod"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   MAVEN_REPO_TOKEN: ${{ github.token }}
 permissions:
@@ -101,7 +102,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || env.KOGITO_RUNTIME_branch }}
           PNPM_FILTER: ${{ steps.setup_build_mode.outputs.bootstrapPnpmFilterString }}
       - name: Modify pom.xml of sonataflow-quarkus-devui
         run: python .github/supporting-files/ci/osl/pom-manipulation/inject-fmp-executions.py

--- a/.github/workflows/ci_build_full.yml
+++ b/.github/workflows/ci_build_full.yml
@@ -29,7 +29,7 @@ on:
 env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
-  KOGITO_RUNTIME_version: "111-SNAPSHOT"
+  KOGITO_RUNTIME_version: "9.106.0"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   MAVEN_REPO_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/ci_build_full.yml
+++ b/.github/workflows/ci_build_full.yml
@@ -77,7 +77,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || 'main' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
           PNPM_FILTER: ""
 
       - name: Modify pom.xml of sonataflow-quarkus-devui

--- a/.github/workflows/ci_build_full.yml
+++ b/.github/workflows/ci_build_full.yml
@@ -30,6 +30,7 @@ env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
   KOGITO_RUNTIME_version: "9.106.0"
+  KOGITO_RUNTIME_branch: "9.106.x-prod"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   MAVEN_REPO_TOKEN: ${{ github.token }}
 
@@ -77,7 +78,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || env.KOGITO_RUNTIME_branch }}
           PNPM_FILTER: ""
 
       - name: Modify pom.xml of sonataflow-quarkus-devui

--- a/.github/workflows/ci_build_image_e2e_tests.yml
+++ b/.github/workflows/ci_build_image_e2e_tests.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
-  KOGITO_RUNTIME_version: "111-SNAPSHOT"
+  KOGITO_RUNTIME_version: "9.106.0"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   MAVEN_REPO_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/ci_build_image_e2e_tests.yml
+++ b/.github/workflows/ci_build_image_e2e_tests.yml
@@ -32,6 +32,7 @@ env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
   KOGITO_RUNTIME_version: "9.106.0"
+  KOGITO_RUNTIME_branch: "9.106.x-prod"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   MAVEN_REPO_TOKEN: ${{ github.token }}
 
@@ -92,7 +93,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || env.KOGITO_RUNTIME_branch }}
           PNPM_FILTER: "-F ${{ matrix.package.pnpmName }}..."
 
       - name: Modify pom.xml of sonataflow-quarkus-devui

--- a/.github/workflows/ci_build_image_e2e_tests.yml
+++ b/.github/workflows/ci_build_image_e2e_tests.yml
@@ -92,7 +92,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || 'main' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
           PNPM_FILTER: "-F ${{ matrix.package.pnpmName }}..."
 
       - name: Modify pom.xml of sonataflow-quarkus-devui

--- a/.github/workflows/ci_build_non_image_e2e_tests.yml
+++ b/.github/workflows/ci_build_non_image_e2e_tests.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
-  KOGITO_RUNTIME_version: "111-SNAPSHOT"
+  KOGITO_RUNTIME_version: "9.106.0"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   MAVEN_REPO_TOKEN: ${{ github.token }}
   PNPM_FILTER: >-

--- a/.github/workflows/ci_build_non_image_e2e_tests.yml
+++ b/.github/workflows/ci_build_non_image_e2e_tests.yml
@@ -32,6 +32,7 @@ env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
   KOGITO_RUNTIME_version: "9.106.0"
+  KOGITO_RUNTIME_branch: "9.106.x-prod"
   MAVEN_ARGS: "-B -s ${{ github.workspace }}/.github/supporting-files/ci/midstream-mvn-config/settings.xml"
   MAVEN_REPO_TOKEN: ${{ github.token }}
   PNPM_FILTER: >-
@@ -78,7 +79,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || env.KOGITO_RUNTIME_branch }}
           PNPM_FILTER: ${{ env.PNPM_FILTER }}
 
       - name: Modify pom.xml of sonataflow-quarkus-devui

--- a/.github/workflows/ci_build_non_image_e2e_tests.yml
+++ b/.github/workflows/ci_build_non_image_e2e_tests.yml
@@ -78,7 +78,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || 'main' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
           PNPM_FILTER: ${{ env.PNPM_FILTER }}
 
       - name: Modify pom.xml of sonataflow-quarkus-devui

--- a/.github/workflows/ci_build_operator_full.yml
+++ b/.github/workflows/ci_build_operator_full.yml
@@ -79,7 +79,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || 'main' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
           PNPM_FILTER: ""
           USE_OSL_ENV_CONFIG: false
 

--- a/.github/workflows/ci_build_operator_full.yml
+++ b/.github/workflows/ci_build_operator_full.yml
@@ -27,7 +27,7 @@ on:
 env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
-  KOGITO_RUNTIME_version: "111-SNAPSHOT"
+  KOGITO_RUNTIME_version: "9.106.0"
   SONATAFLOW_QUARKUS_DEVUI_VERSION: "111-SNAPSHOT"
   SONATAFLOW_DEVMODE_IMAGE__sonataflowQuarkusDevUiVersion: "111-SNAPSHOT"
   QUARKUS_PLATFORM_version: "3.33.3"

--- a/.github/workflows/ci_build_operator_full.yml
+++ b/.github/workflows/ci_build_operator_full.yml
@@ -28,6 +28,7 @@ env:
   TMPDIR: "/tmp"
   BUILD_ENV__accessErrorsLogFileAbsolutePath: "/tmp/build-env-access-errors.log"
   KOGITO_RUNTIME_version: "9.106.0"
+  KOGITO_RUNTIME_branch: "9.106.x-prod"
   SONATAFLOW_QUARKUS_DEVUI_VERSION: "111-SNAPSHOT"
   SONATAFLOW_DEVMODE_IMAGE__sonataflowQuarkusDevUiVersion: "111-SNAPSHOT"
   QUARKUS_PLATFORM_version: "3.33.3"
@@ -79,7 +80,7 @@ jobs:
         uses: ./.github/actions/setup-kie-tools
         with:
           KOGITO_VERSION: ${{ env.KOGITO_RUNTIME_version }}
-          DEPS_BRANCHNAME: ${{ github.head_ref || '9.106.x-prod' }}
+          DEPS_BRANCHNAME: ${{ github.head_ref || env.KOGITO_RUNTIME_branch }}
           PNPM_FILTER: ""
           USE_OSL_ENV_CONFIG: false
 


### PR DESCRIPTION
## SRVLOGIC-1153: fix CI dependency resolution on the 9.106.x-prod release branch

### Problem

CI checks on this release branch resolve their kogito dependencies from the
wrong source, so builds fail with:

```
Non-resolvable import POM: org.kie.kogito:kogito-bom:pom:9.106.0 (absent)
```

Two root causes:

1. `KOGITO_RUNTIME_version` was still `111-SNAPSHOT` (main's dev value) in
   several workflows.
2. Workflows passed `DEPS_BRANCHNAME: ${{ github.head_ref || 'main' }}` to
   `setup-kie-tools`. On pull_request events `github.head_ref` is always the
   feature branch, so the default never fires; the feature branch does not exist
   under `kiegroup/*`, so `setup-maven-cache` fell back to its hardcoded `main`
   and built SNAPSHOT deps that do not satisfy `kogito-bom:9.106.0`.

### Changes

- Pin `KOGITO_RUNTIME_version` to `9.106.0` in the release-branch CI workflows.
- Set the deps-branch default to `9.106.x-prod` (instead of `main`) in the
  affected workflows.
- Add a `FALLBACK_BRANCHNAME` input (default `9.106.x-prod`) to
  `setup-maven-cache` and use it in all six kiegroup lookups (cache-key
  `git ls-remote` and clone) instead of the hardcoded `main`. On main this
  input is simply set to main, keeping the action stream-agnostic.
- Remove an unreachable maven-cache step from the `bootstrap` action (dead code
  keyed off head_ref).

### Notes

- This PR intentionally does NOT enable the E2E suites. Those jobs currently fail
  for an unrelated reason (the Quarkus SP2 version introduced via #462) which is
  tracked separately. The regular CI :: Build check still exercises the fixed
  dependency resolution.
- The matrix.partition / setup_build_mode actionlint findings are pre-existing
  and unrelated to this change.
