### PR TITLE
SRVLOGIC-1153 | Add missing install.js to sonataflow-management-console-image so image e2e finds the built image

### DIFF
--- a/packages/sonataflow-management-console-image/install.js
+++ b/packages/sonataflow-management-console-image/install.js
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const path = require("path");
+const { runKogitoImageInstall } = require("@kie/kogito-images-install-helper");
+const { env } = require("./env");
+
+const { buildTag, registry, account, name: imageName } = env.sonataflowManagementConsoleImageEnv;
+
+runKogitoImageInstall({
+  finalImageName: "sonataflow-management-console",
+  imageTag: { buildTag, registry, account, name: imageName },
+  resourceDir: path.resolve(__dirname, "./resources"),
+  requiresMvn: false,
+});

--- a/packages/sonataflow-management-console-image/package.json
+++ b/packages/sonataflow-management-console-image/package.json
@@ -26,6 +26,7 @@
     "copy:webapp-assets:linux:darwin": "cp -R ./node_modules/@kie-tools/sonataflow-management-console-webapp/dist/ ./dist-dev/sonataflow-management-console-webapp",
     "copy:webapp-assets:win32": "pnpm powershell \"Copy-Item -R ./node_modules/@kie-tools/sonataflow-management-console-webapp/dist/ ./dist-dev/sonataflow-management-console-webapp\"",
     "env-json:schema:generate": "ts-json-schema-generator --tsconfig ./node_modules/@kie-tools/sonataflow-management-console-webapp/tsconfig.json --path ./node_modules/@kie-tools/sonataflow-management-console-webapp/src/env/EnvJson.ts --type EnvJson --id EnvJson --out ./dist-dev/EnvJson.schema.json",
+    "format": "prettier --write . --ignore-path=../../.prettierignore --ignore-path=../../.gitignore",
     "image:cekit:build": "run-script-os",
     "image:cekit:build:darwin:win32": "echo \"Build skipped on Mac and Windows\"",
     "image:cekit:build:linux": "pnpm image:cekit:copy && pnpm image:cekit:setup:env make -C ./dist-dev build",
@@ -33,7 +34,8 @@
     "image:cekit:setup:env": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && cross-env KOGITO_IMAGE_REGISTRY=$(build-env sonataflowManagementConsoleImageEnv.registry) KOGITO_IMAGE_REGISTRY_ACCOUNT=$(build-env sonataflowManagementConsoleImageEnv.account) KOGITO_IMAGE_NAME=$(build-env sonataflowManagementConsoleImageEnv.name) KOGITO_IMAGE_TAG=$(build-env sonataflowManagementConsoleImageEnv.buildTag) QUARKUS_PLATFORM_GROUPID=$(build-env kogitoImagesCekitModules.quarkusGroupId) QUARKUS_PLATFORM_VERSION=$(build-env versions.quarkus) KOGITO_VERSION=$(build-env versions.kogito) SONATAFLOW_MANAGEMENT_CONSOLE_PORT=$(build-env sonataflowManagementConsoleImageEnv.port)",
     "image:test": "run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env endToEndTests.run)\" --then \"mkdir -p dist-dev/target/test/results\" \"run-script-os\" --finally \"cp -R dist-dev/target/test/results dist-tests-e2e/\"",
     "image:test:darwin:win32": "echo \"Tests skipped on Mac and Windows\"",
-    "image:test:linux": "pnpm copy:test-assets && pnpm image:cekit:setup:env make -C ./dist-dev test-image"
+    "image:test:linux": "pnpm copy:test-assets && pnpm image:cekit:setup:env make -C ./dist-dev test-image",
+    "install": "node install.js && pnpm format"
   },
   "devDependencies": {
     "@kie-tools/image-env-to-json": "workspace:*",
@@ -42,7 +44,9 @@
     "@kie-tools/sonataflow-image-common": "workspace:*",
     "@kie-tools/sonataflow-management-console-image-env": "workspace:*",
     "@kie-tools/sonataflow-management-console-webapp": "workspace:*",
+    "@kie/kogito-images-install-helper": "workspace:*",
     "cross-env": "^7.0.3",
+    "replace-in-file": "^7.1.0",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.6",
     "start-server-and-test": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6743,9 +6743,15 @@ importers:
       '@kie-tools/sonataflow-management-console-webapp':
         specifier: workspace:*
         version: link:../sonataflow-management-console-webapp
+      '@kie/kogito-images-install-helper':
+        specifier: workspace:*
+        version: link:../kogito-images-install-helper
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      replace-in-file:
+        specifier: ^7.1.0
+        version: 7.1.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2


### PR DESCRIPTION
https://redhat.atlassian.net/browse/SRVLOGIC-1153

Adds the missing install.js to sonataflow-management-console-image so its CEKit image descriptor version is bumped to the build tag (streamName) at install time, mirroring the sibling image packages (devmode/builder/osl-management-console).

Background: management-console-image was the only sibling image package without an install.js, so its descriptor version stayed at "main". On a release branch the image is built and tagged as ...:1.39.0, but cekit test behave resolves the tested image from the descriptor version ("main"), which does not exist, causing docker.errors.ImageNotFound ...:main and a full image-e2e failure. Adding install.js (delegating to @kie/kogito-images-install-helper) makes versions_manager.py --bump-to <buildTag> set the descriptor version dynamically, so the test finds the built image. On main the buildTag is "main" so the bump is a no-op.

run standard e2e
